### PR TITLE
refactor: remove `main_desktop.dart` and add Clang `stdlib=libc++` 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libc++-dev libc++abi-dev
 
       - name: Enable Linux desktop
         if: matrix.os == 'ubuntu-latest'

--- a/example/lib/main_desktop.dart
+++ b/example/lib/main_desktop.dart
@@ -1,8 +1,0 @@
-import 'package:file_picker_example/src/file_picker_demo.dart';
-import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
-
-void main() {
-  debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;
-  runApp(FilePickerDemo());
-}

--- a/example/lib/src/file_picker_demo.dart
+++ b/example/lib/src/file_picker_demo.dart
@@ -79,7 +79,7 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
     _resetState();
 
     try {
-      pickedFiles = (await FilePicker.platform.pickFiles(
+      final result = await FilePicker.platform.pickFiles(
         type: _pickingType,
         allowMultiple: _multiPick,
         onFileLoading: (FilePickerStatus status) => setState(() {
@@ -92,8 +92,9 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
         initialDirectory: _initialDirectoryController.text,
         lockParentWindow: _lockParentWindow,
         withData: true,
-      ))
-          ?.files;
+      );
+      printInDebug("pickedFiles: $result");
+      pickedFiles = result?.files;
       hasUserAborted = pickedFiles == null;
     } on PlatformException catch (e) {
       _logException('Unsupported operation: $e');

--- a/example/linux/CMakeLists.txt
+++ b/example/linux/CMakeLists.txt
@@ -44,6 +44,11 @@ function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_options(${TARGET} PRIVATE -Wall -Werror)
   target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
   target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
+
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    target_compile_options(${TARGET} PRIVATE -stdlib=libc++)
+    target_link_options(${TARGET} PRIVATE -stdlib=libc++)
+  endif()
 endfunction()
 
 # Flutter library and tool build rules.

--- a/example/linux/CMakeLists.txt
+++ b/example/linux/CMakeLists.txt
@@ -45,7 +45,10 @@ function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
   target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
 
-
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    target_compile_options(${TARGET} PRIVATE -stdlib=libc++)
+    target_link_options(${TARGET} PRIVATE -stdlib=libc++)
+  endif()
 endfunction()
 
 # Flutter library and tool build rules.

--- a/example/linux/CMakeLists.txt
+++ b/example/linux/CMakeLists.txt
@@ -45,10 +45,7 @@ function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
   target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
 
-  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    target_compile_options(${TARGET} PRIVATE -stdlib=libc++)
-    target_link_options(${TARGET} PRIVATE -stdlib=libc++)
-  endif()
+
 endfunction()
 
 # Flutter library and tool build rules.


### PR DESCRIPTION
The most notable change in this PR is an update to the Linux build configuration to ensure compatibility with Clang by explicitly specifying the use of the `libc++` standard library. Additionally, an unused desktop entry point file was removed.

Build system improvements:

* Updated `example/linux/CMakeLists.txt` to add `-stdlib=libc++` compiler and linker flags when building with Clang, improving compatibility and portability.

Code cleanup:

* Removed the unused `example/lib/main_desktop.dart` file.