### PR TITLE
Add Flutter 3.35.0 to CI test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        flutter: [ '3.24.0', '3.27.0', '3.29.0', '3.32.0', 'stable', 'beta' ]
+        flutter: [ '3.24.0', '3.27.0', '3.29.0', '3.32.0', '3.35.0', 'stable', 'beta' ]
     name: Tests on Flutter ${{ matrix.flutter }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Adds Flutter version 3.35.0 to the build matrix in the GitHub Actions workflow.