### PR TITLE
ci: Dynamically fetch Flutter versions for the CI test matrix instead…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,12 +7,24 @@ on:
     branches: [ master ]
 
 jobs:
+  setup_flutter_versions:
+    runs-on: ubuntu-latest
+    outputs:
+      flutter-versions: ${{ steps.id_flutter_versions.outputs.versions }}
+    steps:
+      - name: Fetch Flutter versions
+        id: id_flutter_versions
+        run: |
+          VERSIONS=$(curl -s https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json | jq -c '[.releases | map(select(.channel == "stable")) | .[:5] | map(.version)] | flatten + ["stable", "beta"]')
+          echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
+
   test_flutter_versions:
+    needs: setup_flutter_versions
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        flutter: [ '3.24.0', '3.27.0', '3.29.0', '3.32.0', '3.35.0', 'stable', 'beta' ]
+        flutter: ${{ fromJson(needs.setup_flutter_versions.outputs.flutter-versions) }}
     name: Tests on Flutter ${{ matrix.flutter }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Fetch Flutter versions
         id: id_flutter_versions
         run: |
-          VERSIONS=$(curl -s https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json | jq -c '[.releases | map(select(.channel == "stable")) | .[:5] | map(.version)] | flatten + ["stable", "beta"]')
+          VERSIONS=$(curl -s https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json | jq -c '[.releases | map(select(.channel == "stable")) | group_by(.version | split(".")[:2] | join(".")) | map(.[0]) | sort_by(.release_date) | reverse | .[:5] | map(.version)] | flatten + ["stable", "beta"]')
           echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
 
   test_flutter_versions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,11 @@ jobs:
     outputs:
       flutter-versions: ${{ steps.id_flutter_versions.outputs.versions }}
     steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
       - name: Fetch Flutter versions
         id: id_flutter_versions
-        run: |
-          VERSIONS=$(curl -s https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json | jq -c '[.releases | map(select(.channel == "stable")) | group_by(.version | split(".")[:2] | join(".")) | map(.[0]) | sort_by(.release_date) | reverse | .[:5] | map(.version)] | flatten + ["stable", "beta"]')
-          echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
+        run: dart tool/fetch_versions.dart >> $GITHUB_OUTPUT
 
   test_flutter_versions:
     needs: setup_flutter_versions

--- a/test/fetch_versions_test.dart
+++ b/test/fetch_versions_test.dart
@@ -3,7 +3,7 @@ import '../tool/fetch_versions.dart';
 
 void main() {
   test(
-      'parseVersions extracts last 6 minor versions, skips 1st, returns 5 + stable/beta',
+      'parseVersions extracts last 5 minor versions, skips 1st, returns 4 + stable/beta',
       () {
     final json = {
       "releases": [
@@ -71,10 +71,10 @@ void main() {
       "3.32.8",
       "3.29.3",
       "3.27.4",
-      "3.24.2",
+      // "3.24.2", // Removed
       "stable",
       "beta"
     ]);
-    expect(versions.length, 7);
+    expect(versions.length, 6);
   });
 }

--- a/test/fetch_versions_test.dart
+++ b/test/fetch_versions_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import '../tool/fetch_versions.dart';
+
+void main() {
+  test('parseVersions extracts last 4 minor versions + stable/beta', () {
+    final json = {
+      "releases": [
+        // Minor 3.38
+        {
+          "version": "3.38.5",
+          "channel": "stable",
+          "release_date": "2025-12-12T10:00:00Z"
+        },
+        {
+          "version": "3.38.4",
+          "channel": "stable",
+          "release_date": "2025-12-11T10:00:00Z"
+        },
+
+        // Minor 3.35
+        {
+          "version": "3.35.7",
+          "channel": "stable",
+          "release_date": "2025-11-12T10:00:00Z"
+        },
+
+        // Minor 3.32
+        {
+          "version": "3.32.8",
+          "channel": "stable",
+          "release_date": "2025-10-12T10:00:00Z"
+        },
+
+        // Minor 3.29
+        {
+          "version": "3.29.3",
+          "channel": "stable",
+          "release_date": "2025-09-12T10:00:00Z"
+        },
+
+        // Minor 3.27 (5th older minor, should be excluded if limit is 4)
+        {
+          "version": "3.27.4",
+          "channel": "stable",
+          "release_date": "2025-08-12T10:00:00Z"
+        },
+
+        // Beta (ignored by filter, but 'beta' string is added manually)
+        {
+          "version": "3.40.0-beta",
+          "channel": "beta",
+          "release_date": "2025-12-13T10:00:00Z"
+        },
+      ]
+    };
+
+    final versions = parseVersions(json);
+
+    expect(versions, [
+      "3.38.5", // Latest of 3.38
+      "3.35.7", // Latest of 3.35
+      "3.32.8", // Latest of 3.32
+      "3.29.3", // Latest of 3.29
+      "stable",
+      "beta"
+    ]);
+    expect(versions.length, 6);
+  });
+}

--- a/test/fetch_versions_test.dart
+++ b/test/fetch_versions_test.dart
@@ -2,7 +2,9 @@ import 'package:flutter_test/flutter_test.dart';
 import '../tool/fetch_versions.dart';
 
 void main() {
-  test('parseVersions extracts last 4 minor versions + stable/beta', () {
+  test(
+      'parseVersions extracts last 6 minor versions, skips 1st, returns 5 + stable/beta',
+      () {
     final json = {
       "releases": [
         // Minor 3.38
@@ -38,11 +40,18 @@ void main() {
           "release_date": "2025-09-12T10:00:00Z"
         },
 
-        // Minor 3.27 (5th older minor, should be excluded if limit is 4)
+        // Minor 3.27
         {
           "version": "3.27.4",
           "channel": "stable",
           "release_date": "2025-08-12T10:00:00Z"
+        },
+
+        // Minor 3.24
+        {
+          "version": "3.24.2",
+          "channel": "stable",
+          "release_date": "2025-07-12T10:00:00Z"
         },
 
         // Beta (ignored by filter, but 'beta' string is added manually)
@@ -57,13 +66,15 @@ void main() {
     final versions = parseVersions(json);
 
     expect(versions, [
-      "3.38.5", // Latest of 3.38
-      "3.35.7", // Latest of 3.35
-      "3.32.8", // Latest of 3.32
-      "3.29.3", // Latest of 3.29
+      // "3.38.5", // Skipped
+      "3.35.7",
+      "3.32.8",
+      "3.29.3",
+      "3.27.4",
+      "3.24.2",
       "stable",
       "beta"
     ]);
-    expect(versions.length, 6);
+    expect(versions.length, 7);
   });
 }

--- a/test/fetch_versions_test.dart
+++ b/test/fetch_versions_test.dart
@@ -75,6 +75,5 @@ void main() {
       "stable",
       "beta"
     ]);
-    expect(versions.length, 6);
   });
 }

--- a/tool/fetch_versions.dart
+++ b/tool/fetch_versions.dart
@@ -59,15 +59,16 @@ List<String> parseVersions(Map<String, Object?> json) {
     if (parts.length < 2) continue;
     final minor = '${parts[0]}.${parts[1]}';
 
-    if (!latestByMinor.containsKey(minor)) {
-      latestByMinor[minor] = release;
-    } else {
+    if (latestByMinor.containsKey(minor)) {
       final currentBest = latestByMinor[minor]!;
       // Keep the most recent patch
       if (release.releaseDate.isAfter(currentBest.releaseDate)) {
         latestByMinor[minor] = release;
       }
+      continue;
     }
+
+    latestByMinor[minor] = release;
   }
 
   // Sort groups by release date descending

--- a/tool/fetch_versions.dart
+++ b/tool/fetch_versions.dart
@@ -1,0 +1,73 @@
+import 'dart:convert';
+import 'dart:io';
+
+Future<void> main() async {
+  try {
+    final json = await _fetchJson();
+    final versions = parseVersions(json);
+    print('versions=${jsonEncode(versions)}');
+  } catch (e) {
+    stderr.writeln('Error: $e');
+    exit(1);
+  }
+}
+
+Future<Map<String, dynamic>> _fetchJson() async {
+  final url = Uri.parse(
+      'https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json');
+  final httpClient = HttpClient();
+  try {
+    final request = await httpClient.getUrl(url);
+    final response = await request.close();
+    if (response.statusCode != 200) {
+      throw HttpException('Failed to fetch releases: ${response.statusCode}');
+    }
+    final responseBody = await response.transform(utf8.decoder).join();
+    return jsonDecode(responseBody) as Map<String, dynamic>;
+  } finally {
+    httpClient.close();
+  }
+}
+
+List<String> parseVersions(Map<String, dynamic> json) {
+  final releases = (json['releases'] as List).cast<Map<String, dynamic>>();
+
+  // Filter for stable channel
+  final stableReleases = releases.where((r) => r['channel'] == 'stable');
+
+  // Group by Major.Minor (e.g. 3.38)
+  final Map<String, Map<String, dynamic>> latestByMinor = {};
+
+  for (final release in stableReleases) {
+    final version = release['version'] as String;
+    final parts = version.split('.');
+    if (parts.length < 2) continue;
+    final minor = '${parts[0]}.${parts[1]}';
+
+    final releaseDate = DateTime.parse(release['release_date']);
+
+    if (!latestByMinor.containsKey(minor)) {
+      latestByMinor[minor] = release;
+    } else {
+      final currentBest = latestByMinor[minor]!;
+      final currentBestDate = DateTime.parse(currentBest['release_date']);
+      // Keep the most recent patch
+      if (releaseDate.isAfter(currentBestDate)) {
+        latestByMinor[minor] = release;
+      }
+    }
+  }
+
+  // Sort groups by release date descending
+  final sortedByDate = latestByMinor.values.toList()
+    ..sort((a, b) {
+      final dateA = DateTime.parse(a['release_date']);
+      final dateB = DateTime.parse(b['release_date']);
+      return dateB.compareTo(dateA);
+    });
+
+  // Take the last 4 minor versions
+  final top4 = sortedByDate.take(4).map((r) => r['version'] as String).toList();
+
+  return [...top4, 'stable', 'beta'];
+}

--- a/tool/fetch_versions.dart
+++ b/tool/fetch_versions.dart
@@ -23,7 +23,7 @@ Future<Map<String, Object?>> _fetchJson() async {
       throw HttpException('Failed to fetch releases: ${response.statusCode}');
     }
     final responseBody = await response.transform(utf8.decoder).join();
-    return jsonDecode(responseBody) as Map<String, dynamic>;
+    return jsonDecode(responseBody) as Map<String, Object?>;
   } finally {
     httpClient.close();
   }

--- a/tool/fetch_versions.dart
+++ b/tool/fetch_versions.dart
@@ -36,7 +36,7 @@ List<String> parseVersions(Map<String, Object?> json) {
   final stableReleases = releases.where((r) => r['channel'] == 'stable');
 
   // Group by Major.Minor (e.g. 3.38)
-  final Map<String, Map<String, dynamic>> latestByMinor = {};
+  final Map<String, Map<String, Object?>> latestByMinor = {};
 
   for (final release in stableReleases) {
     final version = release['version'] as String;

--- a/tool/fetch_versions.dart
+++ b/tool/fetch_versions.dart
@@ -29,7 +29,7 @@ Future<Map<String, Object?>> _fetchJson() async {
   }
 }
 
-List<String> parseVersions(Map<String, dynamic> json) {
+List<String> parseVersions(Map<String, Object?> json) {
   final releases = (json['releases'] as List).cast<Map<String, dynamic>>();
 
   // Filter for stable channel

--- a/tool/fetch_versions.dart
+++ b/tool/fetch_versions.dart
@@ -12,7 +12,7 @@ Future<void> main() async {
   }
 }
 
-Future<Map<String, dynamic>> _fetchJson() async {
+Future<Map<String, Object?>> _fetchJson() async {
   final url = Uri.parse(
       'https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json');
   final httpClient = HttpClient();

--- a/tool/fetch_versions.dart
+++ b/tool/fetch_versions.dart
@@ -66,12 +66,12 @@ List<String> parseVersions(Map<String, dynamic> json) {
       return dateB.compareTo(dateA);
     });
 
-  // Take the last 6 minor versions
-  final top6 = sortedByDate.take(6).map((r) => r['version'] as String).toList();
+  // Take the last 5 minor versions
+  final top5 = sortedByDate.take(5).map((r) => r['version'] as String).toList();
 
   // Skip the first one (latest stable) to avoid duplication with 'stable' channel
-  // Return the next 5
-  final historicVersions = top6.skip(1).toList();
+  // Return the next 4
+  final historicVersions = top5.skip(1).toList();
 
   return [...historicVersions, 'stable', 'beta'];
 }

--- a/tool/fetch_versions.dart
+++ b/tool/fetch_versions.dart
@@ -66,8 +66,12 @@ List<String> parseVersions(Map<String, dynamic> json) {
       return dateB.compareTo(dateA);
     });
 
-  // Take the last 4 minor versions
-  final top4 = sortedByDate.take(4).map((r) => r['version'] as String).toList();
+  // Take the last 6 minor versions
+  final top6 = sortedByDate.take(6).map((r) => r['version'] as String).toList();
 
-  return [...top4, 'stable', 'beta'];
+  // Skip the first one (latest stable) to avoid duplication with 'stable' channel
+  // Return the next 5
+  final historicVersions = top6.skip(1).toList();
+
+  return [...historicVersions, 'stable', 'beta'];
 }

--- a/tool/flutter_release.dart
+++ b/tool/flutter_release.dart
@@ -1,0 +1,38 @@
+/// Represents a single Flutter release entry from the JSON feed.
+///
+/// Contains the version string and the release date.
+class FlutterRelease {
+  /// The raw version string (e.g., "3.32.8").
+  final String version;
+
+  /// The date when this version was released.
+  final DateTime releaseDate;
+
+  /// Creates a [FlutterRelease] instance.
+  FlutterRelease({
+    required this.version,
+    required this.releaseDate,
+  });
+
+  /// Tries to parse a JSON object into a [FlutterRelease].
+  ///
+  /// Returns `null` if the JSON object does not have the expected structure
+  /// or if it represents a non-stable channel release (though filtering
+  /// might happen outside, this parser strictly checks for keys).
+  ///
+  /// Note: The logic requires 'channel': 'stable' to be present.
+  static FlutterRelease? tryParse(Object? json) {
+    if (json
+        case {
+          'channel': 'stable',
+          'version': final String version,
+          'release_date': final String releaseDateString
+        }) {
+      return FlutterRelease(
+        version: version,
+        releaseDate: DateTime.parse(releaseDateString),
+      );
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to dynamically fetch and use the latest stable Flutter versions for testing, instead of hardcoding them. This makes it easier to keep tests up-to-date with new Flutter releases.

**Workflow improvements:**

* Added a new `setup_flutter_versions` job that fetches the five latest stable Flutter versions (plus "stable" and "beta" channels) from the Flutter releases API and exposes them as an output for downstream jobs.
* Updated the `test_flutter_versions` job to use the dynamically fetched Flutter versions from the `setup_flutter_versions` job, replacing the previously hardcoded list.