### PR TITLE
chore(example): tidy analysis_options.yaml excludes

### DIFF
--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -7,6 +7,15 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 linter:


### PR DESCRIPTION
## Summary
- Excludes generated platform folders (`android/`, `ios/`, `web/`, `windows/`, `macos/`, `linux/`, `build/`) from analysis in `example/analysis_options.yaml`, mirroring the root config.

## Test plan
- [x] `flutter pub get` in `example/` resolves cleanly
- [x] `flutter analyze .` in `example/` — no issues
- [x] `flutter test` in `example/` — all tests pass