### PR TITLE
file_picker_darwin: actually write the bytes to disk

### DIFF
--- a/packages/file_picker_darwin/CHANGELOG.md
+++ b/packages/file_picker_darwin/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fixed `MissingPluginException` on macOS by registering the event channel stream handler.
 - Fixed method channel handling on macOS to support all file types and actions (`any`, `image`, `video`, `audio`, `media`, `custom`, `dir`, `save`).
+- Fixed `saveFile` on macOS not writing the provided file `bytes` to the chosen location.
 - Added safe argument unwrapping in macOS handler to prevent runtime crashes when arguments are null.
 - Added native `UTType` file type filtering for macOS file dialogs.
 

--- a/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/MacOSFilePickerHandler.swift
+++ b/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/MacOSFilePickerHandler.swift
@@ -251,12 +251,25 @@ final class MacOSFilePickerHandler: NSObject, FlutterStreamHandler {
                 return
             }
 
-            if let url = dialog.url {
-                result(url.path)
+            guard let url = dialog.url else {
+                result(nil)
                 return
             }
 
-            result(nil)
+            if let bytes = args["bytes"] as? FlutterStandardTypedData {
+                do {
+                    try bytes.data.write(to: url, options: .atomic)
+                } catch {
+                    result(
+                        FlutterError(
+                            code: "save_file_error",
+                            message: error.localizedDescription,
+                            details: nil))
+                    return
+                }
+            }
+
+            result(url.path)
         }
     }
 

--- a/packages/file_picker_darwin/pubspec.yaml
+++ b/packages/file_picker_darwin/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_picker_darwin
 description: iOS and macOS implementation of the file_picker plugin.
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_darwin
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_darwin
 topics:


### PR DESCRIPTION
Tried to use the `saveFile` function in patched `file_picker_darwin 1.0.1`, but no file was written on macOS.
This patch fixes the issue for me.
I am not familiar with Swift so is written by Claude (Take it with a big grain of salt). 
Implementations on other platforms should probably be verified as well !
