### PR TITLE
Relax file_picker_linux dbus to ^0.7.13

### DIFF
--- a/packages/file_picker_linux/CHANGELOG.md
+++ b/packages/file_picker_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+- Relax `dbus` to `^0.7.13` so dependents can resolve `xml` 7. [#2130](https://github.com/miguelpruivo/flutter_file_picker/issues/2130)
+
 ## 1.0.0
 
 - Initial release of Linux implementation package for `file_picker`.

--- a/packages/file_picker_linux/pubspec.yaml
+++ b/packages/file_picker_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_picker_linux
 description: Linux implementation of the file_picker plugin.
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_linux
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_linux
 topics:
@@ -25,7 +25,7 @@ dependencies:
     sdk: flutter
   file_picker_platform_interface: ^3.0.0
   cross_file: ^0.3.5+4
-  dbus: ^0.7.14
+  dbus: ^0.7.13
   path: ^1.9.0
 
 dev_dependencies:


### PR DESCRIPTION
`file_picker_linux` pinned `dbus: ^0.7.14`. That version is a revert of 0.7.13 and keeps `xml` on 6.x. `^0.7.13` still accepts 0.7.14, so existing locks stay put, and dependents can take xml 7.

Fixes #2130
