### PR TITLE
fix(darwin): pickFileAndDirectoryPaths now returns real directories

### DIFF
--- a/packages/file_picker_darwin/CHANGELOG.md
+++ b/packages/file_picker_darwin/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.0.1
 
+- Fixed `pickFileAndDirectoryPaths` never returning directories on iOS and macOS. It now calls the native combined file and directory picker instead of silently falling back to file only selection.
 - Fixed `MissingPluginException` on macOS by registering the event channel stream handler.
 - Fixed method channel handling on macOS to support all file types and actions (`any`, `image`, `video`, `audio`, `media`, `custom`, `dir`, `save`).
 - Added safe argument unwrapping in macOS handler to prevent runtime crashes when arguments are null.

--- a/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/IOSFilePickerHandler.swift
+++ b/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/IOSFilePickerHandler.swift
@@ -17,6 +17,7 @@ final class IOSFilePickerHandler: NSObject,
     private var allowMultipleSelection = false
     private var loadDataToMemory = false
     private var isDirectoryPicker = false
+    private var isFileAndDirectoryPicker = false
     private var isSaveFile = false
 
     func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
@@ -95,6 +96,18 @@ final class IOSFilePickerHandler: NSObject,
                 asDirectoryPicker: false)
         case "save":
             saveFile(arguments)
+        case "pickFileAndDirectoryPaths":
+            let allowed = arguments["allowedExtensions"] as? [String] ?? []
+            var contentTypes = allowed.isEmpty ? [.item] : resolveCustomContentTypes(allowed)
+            if contentTypes.isEmpty {
+                contentTypes = [.item]
+            }
+            contentTypes.append(.folder)
+            isFileAndDirectoryPicker = true
+            presentDocumentPicker(
+                contentTypes: contentTypes,
+                allowsMultipleSelection: true,
+                asDirectoryPicker: false)
         default:
             result(FlutterMethodNotImplemented)
             self.result = nil
@@ -199,6 +212,13 @@ final class IOSFilePickerHandler: NSObject,
             currentResult(urls.first?.path)
             result = nil
             isDirectoryPicker = false
+            return
+        }
+
+        if isFileAndDirectoryPicker {
+            currentResult(urls.map { $0.path })
+            result = nil
+            isFileAndDirectoryPicker = false
             return
         }
 
@@ -379,6 +399,8 @@ final class IOSFilePickerHandler: NSObject,
             isSaveFile = false
         }
 
+        isDirectoryPicker = false
+        isFileAndDirectoryPicker = false
         result = nil
         currentResult(value)
     }

--- a/packages/file_picker_darwin/lib/src/file_picker_darwin.dart
+++ b/packages/file_picker_darwin/lib/src/file_picker_darwin.dart
@@ -134,13 +134,18 @@ class FilePickerDarwin extends FilePickerPlatform {
     FileType type = FileType.any,
     List<String>? allowedExtensions,
   }) async {
-    final files = await pickFiles(
-      dialogTitle: dialogTitle,
-      initialDirectory: initialDirectory,
-      type: type,
-      allowedExtensions: allowedExtensions,
-    );
-    return files.map((e) => e.uri.path).toList();
+    try {
+      final List<String>? result = await methodChannel
+          .invokeListMethod<String>('pickFileAndDirectoryPaths', {
+            'dialogTitle': dialogTitle,
+            'initialDirectory': initialDirectory,
+            'allowedExtensions': allowedExtensions,
+          });
+      return result ?? [];
+    } on PlatformException catch (ex) {
+      print('[$_tag] Could not resolve file and directory paths: ${ex.message}');
+    }
+    return [];
   }
 
   @override

--- a/packages/file_picker_darwin/lib/src/file_picker_darwin.dart
+++ b/packages/file_picker_darwin/lib/src/file_picker_darwin.dart
@@ -143,7 +143,9 @@ class FilePickerDarwin extends FilePickerPlatform {
           });
       return result ?? [];
     } on PlatformException catch (ex) {
-      print('[$_tag] Could not resolve file and directory paths: ${ex.message}');
+      print(
+        '[$_tag] Could not resolve file and directory paths: ${ex.message}',
+      );
     }
     return [];
   }

--- a/packages/file_picker_darwin/test/file_picker_darwin_test.dart
+++ b/packages/file_picker_darwin/test/file_picker_darwin_test.dart
@@ -22,32 +22,27 @@ void main() {
       expect(file.uri.path, equals('/tmp/test.png'));
     });
 
-    test(
-      'pickFileAndDirectoryPaths calls the native combined picker and '
-      'returns its paths',
-      () async {
-        final picker = FilePickerDarwin();
+    test('pickFileAndDirectoryPaths calls the native combined picker and '
+        'returns its paths', () async {
+      final picker = FilePickerDarwin();
 
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(picker.methodChannel, (call) async {
+            expect(call.method, 'pickFileAndDirectoryPaths');
+            expect((call.arguments as Map)['allowedExtensions'], ['pdf']);
+            return ['/tmp/some_file.pdf', '/tmp/some_directory'];
+          });
+      addTearDown(() {
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(picker.methodChannel, (call) async {
-              expect(call.method, 'pickFileAndDirectoryPaths');
-              expect((call.arguments as Map)['allowedExtensions'], [
-                'pdf',
-              ]);
-              return ['/tmp/some_file.pdf', '/tmp/some_directory'];
-            });
-        addTearDown(() {
-          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-              .setMockMethodCallHandler(picker.methodChannel, null);
-        });
+            .setMockMethodCallHandler(picker.methodChannel, null);
+      });
 
-        final result = await picker.pickFileAndDirectoryPaths(
-          allowedExtensions: ['pdf'],
-        );
+      final result = await picker.pickFileAndDirectoryPaths(
+        allowedExtensions: ['pdf'],
+      );
 
-        expect(result, ['/tmp/some_file.pdf', '/tmp/some_directory']);
-      },
-    );
+      expect(result, ['/tmp/some_file.pdf', '/tmp/some_directory']);
+    });
 
     test(
       'pickFileAndDirectoryPaths returns an empty list on PlatformException',

--- a/packages/file_picker_darwin/test/file_picker_darwin_test.dart
+++ b/packages/file_picker_darwin/test/file_picker_darwin_test.dart
@@ -1,5 +1,6 @@
 import 'package:file_picker_darwin/file_picker_darwin.dart';
 import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -20,5 +21,52 @@ void main() {
       expect(file.name, equals('test.png'));
       expect(file.uri.path, equals('/tmp/test.png'));
     });
+
+    test(
+      'pickFileAndDirectoryPaths calls the native combined picker and '
+      'returns its paths',
+      () async {
+        final picker = FilePickerDarwin();
+
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(picker.methodChannel, (call) async {
+              expect(call.method, 'pickFileAndDirectoryPaths');
+              expect((call.arguments as Map)['allowedExtensions'], [
+                'pdf',
+              ]);
+              return ['/tmp/some_file.pdf', '/tmp/some_directory'];
+            });
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(picker.methodChannel, null);
+        });
+
+        final result = await picker.pickFileAndDirectoryPaths(
+          allowedExtensions: ['pdf'],
+        );
+
+        expect(result, ['/tmp/some_file.pdf', '/tmp/some_directory']);
+      },
+    );
+
+    test(
+      'pickFileAndDirectoryPaths returns an empty list on PlatformException',
+      () async {
+        final picker = FilePickerDarwin();
+
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(picker.methodChannel, (call) async {
+              throw PlatformException(code: 'error');
+            });
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(picker.methodChannel, null);
+        });
+
+        final result = await picker.pickFileAndDirectoryPaths();
+
+        expect(result, isEmpty);
+      },
+    );
   });
 }


### PR DESCRIPTION
Closes #2136 

## Summary
- `pickFileAndDirectoryPaths` on darwin was implemented in Dart by calling `pickFiles` and mapping the results to paths, so directories could never be returned on iOS or macOS.
- The native macOS handler for the combined file and directory picker (`handleFileAndDirectorySelection`) already existed but was unreachable, Dart never called it.
- iOS had no case at all for this method, it fell through to `FlutterMethodNotImplemented`.
- Dart now invokes the dedicated `pickFileAndDirectoryPaths` method channel call on both platforms. Added the missing iOS case, presenting a document picker whose content types include folders alongside the requested file extensions.
- While touching the iOS handler, also reset `isDirectoryPicker` when a request is cancelled or dismissed, it was left stale before and could leak into the next request's dispatch.

## Test plan
- [x] `flutter analyze` and `flutter test` on `file_picker_darwin`, including new tests covering the method channel call shape and the `PlatformException` fallback
- [x] `flutter build ios --simulator` from `example`, real compile of the new native iOS code, not just Dart
- [x] `flutter build macos` from `example`

Targets the `1.0.1` changelog entry, not yet published.