### PR TITLE
fix(linux): relax the dbus constraint to ^0.7.13

### DIFF
--- a/packages/file_picker_linux/CHANGELOG.md
+++ b/packages/file_picker_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+- Relaxed the `dbus` constraint to `^0.7.13` so apps that need `xml` 7 can resolve. Version 0.7.14 is identical to 0.7.13 apart from the `xml` bound, and pub still prefers 0.7.14 by default. [#2130](https://github.com/miguelpruivo/flutter_file_picker/issues/2130)
+
 ## 1.0.0
 
 - Initial release of Linux implementation package for `file_picker`.

--- a/packages/file_picker_linux/pubspec.yaml
+++ b/packages/file_picker_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_picker_linux
 description: Linux implementation of the file_picker plugin.
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_linux
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_linux
 topics:
@@ -25,7 +25,7 @@ dependencies:
     sdk: flutter
   file_picker_platform_interface: ^3.0.0
   cross_file: ^0.3.5+4
-  dbus: ^0.7.14
+  dbus: ^0.7.13
   path: ^1.9.0
 
 dev_dependencies:


### PR DESCRIPTION
Closes #2130.

## What

`file_picker_linux` requires `dbus: ^0.7.14`, and 0.7.14 pins `xml` to `^6.6.1`. Any app that also pulls a package requiring `xml` 7 currently cannot resolve.

This widens the constraint to `^0.7.13`.

## Why this is not a downgrade

`^0.7.13` means `>=0.7.13 <0.8.0`, so 0.7.14 is still in range and pub keeps preferring it. Nothing changes for anyone who does not need `xml` 7.

The two dbus releases are the same code. Diffing the published archives, only three files differ:

```
CHANGELOG.md
lib/src/dbus_introspect.dart
pubspec.yaml
```

and the `dbus_introspect.dart` diff is purely `XmlName.parts('node')` (xml 7 API) vs `XmlName('node')` (xml 6 API). Both releases include the Windows fix from 0.7.13, and neither is retracted.

| version | xml dep | published |
| --- | --- | --- |
| 0.7.13 | `^7.0.0` | 2026-05-22 |
| 0.7.14 | `^6.6.1` | 2026-06-04 |

The dbus 0.7.14 changelog gives the revert reason as "the version that Flutter is using", which refers to `flutter_tools` pinning `xml: 6.6.1`. `flutter_tools` resolves inside the SDK and does not constrain user apps, and neither `flutter` nor `flutter_test` depends on `xml`.

## Verification

Workspace `flutter pub get` on this branch, unchanged from before:

```
dbus 0.7.14
xml  6.6.1
```

Isolated project asking for `dbus: ^0.7.13` plus `xml: ^7.0.0`, which fails on master and now resolves:

```
dbus 0.7.13
xml  7.0.1
```

`xml` 7.0.0 requires Dart `^3.11.0` while this package declares `>=3.10.0`. That is not a conflict: on Dart 3.10 pub simply cannot pick 0.7.13 and falls back to 0.7.14 with `xml` 6.

## Note

The `1.0.1` section added here will conflict with the `1.0.1` section on `docs/pubspec-descriptions-and-dartdocs`, since both branches bump from `1.0.0`. Whichever lands second just merges the two bullet lists.