### PR TITLE
[Windows] Append default extension in save dialog via lpstrDefExt

### DIFF
--- a/packages/file_picker_windows/CHANGELOG.md
+++ b/packages/file_picker_windows/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.2
+
+#### Desktop (Windows)
+
+- Fix saved files missing their extension when the user types a file name without one: set `lpstrDefExt` on `OPENFILENAMEW` so Windows appends the default extension (derived from the allowed extensions or the suggested file name). Fixes [#2139](https://github.com/miguelpruivo/flutter_file_picker/issues/2139).
+
 ## 1.0.1
 
 - Improved package description, added example, and added missing API documentation.

--- a/packages/file_picker_windows/lib/src/file_picker_windows.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows.dart
@@ -450,6 +450,12 @@ class FilePickerWindows extends FilePickerPlatform {
       openFileNameW.ref.flags |= ofnOverwritePrompt;
     }
 
+    // Without lpstrDefExt, Windows does not append an extension when the
+    // user types a file name without one, producing extension-less files.
+    if (resolveDefaultExtension(args) case final defaultExtension?) {
+      openFileNameW.ref.lpstrDefExt = defaultExtension.toNativeUtf16();
+    }
+
     if (args.defaultFileName case final defaultFileName?) {
       validateFileName(defaultFileName);
 
@@ -466,6 +472,24 @@ class FilePickerWindows extends FilePickerPlatform {
     }
 
     return openFileNameW;
+  }
+
+  /// Resolves the default extension (without a leading dot) that Windows
+  /// appends via `lpstrDefExt` when the user types a file name without one.
+  ///
+  /// Prefers the first entry of [OpenSaveFileArgs.allowedExtensions], falling
+  /// back to the extension of [OpenSaveFileArgs.defaultFileName].
+  @visibleForTesting
+  String? resolveDefaultExtension(OpenSaveFileArgs args) {
+    return switch (args.allowedExtensions) {
+      [final first, ...] => first,
+      _ => switch (args.defaultFileName) {
+        final name? when extension(name).length > 1 => extension(
+          name,
+        ).substring(1),
+        _ => null,
+      },
+    };
   }
 
   /// Retrieves the HWND handle of the Flutter runner window using `user32.dll`.
@@ -490,6 +514,9 @@ class FilePickerWindows extends FilePickerPlatform {
     calloc.free(openFileNameW.ref.lpstrFile);
     calloc.free(openFileNameW.ref.lpstrFilter);
     calloc.free(openFileNameW.ref.lpstrInitialDir);
+    if (openFileNameW.ref.lpstrDefExt != nullptr) {
+      calloc.free(openFileNameW.ref.lpstrDefExt);
+    }
     calloc.free(openFileNameW);
   }
 

--- a/packages/file_picker_windows/pubspec.yaml
+++ b/packages/file_picker_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: windows_file_picker
 description: Windows implementation of the file_picker plugin using Win32 COM APIs for native file and directory picking.
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_windows
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_windows
 topics:

--- a/packages/file_picker_windows/test/file_picker_windows_test.dart
+++ b/packages/file_picker_windows/test/file_picker_windows_test.dart
@@ -1,4 +1,7 @@
+import 'dart:isolate';
+
 import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
+import 'package:windows_file_picker/src/open_save_file_args.dart';
 import 'package:windows_file_picker/windows_file_picker.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -24,6 +27,50 @@ void main() {
       );
       expect(options.parentWindowHandle, equals(12345));
       expect(options.lockParentWindow, isTrue);
+    });
+  });
+
+  group('resolveDefaultExtension', () {
+    final picker = FilePickerWindows();
+    final port = ReceivePort();
+    tearDownAll(port.close);
+
+    OpenSaveFileArgs args({
+      List<String>? allowedExtensions,
+      String? defaultFileName,
+    }) {
+      return OpenSaveFileArgs(
+        port: port.sendPort,
+        allowedExtensions: allowedExtensions,
+        defaultFileName: defaultFileName,
+      );
+    }
+
+    test('prefers the first allowed extension', () {
+      expect(
+        picker.resolveDefaultExtension(
+          args(allowedExtensions: ['pdf', 'docx'], defaultFileName: 'a.txt'),
+        ),
+        equals('pdf'),
+      );
+    });
+
+    test('falls back to the extension of the default file name', () {
+      expect(
+        picker.resolveDefaultExtension(args(defaultFileName: 'calendar.pdf')),
+        equals('pdf'),
+      );
+    });
+
+    test('returns null when the default file name has no extension', () {
+      expect(
+        picker.resolveDefaultExtension(args(defaultFileName: 'calendar')),
+        isNull,
+      );
+    });
+
+    test('returns null when there is no extension source at all', () {
+      expect(picker.resolveDefaultExtension(args()), isNull);
     });
   });
 }


### PR DESCRIPTION
Fixes #2139.

**Problem**
On Windows, when the user types a file name **without an extension** in the save dialog, the file is saved without any extension, so the OS cannot associate it with an application. This happens because `lpstrDefExt` is never set on the `OPENFILENAMEW` struct, and `GetSaveFileNameW` only appends a default extension when that field is populated ([OPENFILENAMEW docs](https://learn.microsoft.com/en-us/windows/win32/api/commdlg/ns-commdlg-openfilenamew)).

**Fix**
- Set `lpstrDefExt` in `_instantiateOpenFileNameW`, using the first entry of `allowedExtensions` and falling back to the extension of the suggested `defaultFileName` (which covers the current `saveFile()` API, where no extension list is passed down).
- Free the allocated string in `_freeMemory`.
- The derivation logic is extracted into `resolveDefaultExtension` (`@visibleForTesting`) and covered by unit tests.

Note that Windows only appends the default extension when the typed name has none — a name typed *with* an explicit extension is left untouched, which is the standard Win32 save-dialog behavior.

Per CONTRIBUTING: version bumped to 1.0.2 (patch, bug fix), CHANGELOG updated, `dart analyze` and `dart format` clean, `flutter test` passes (7 tests).
