### PR TITLE
Fall back to the real home directory on sandboxed macOS

### DIFF
--- a/packages/file_picker_darwin/CHANGELOG.md
+++ b/packages/file_picker_darwin/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## 1.0.2
 
 - Fixed a crash (`FileSystemException`/`OSError: Is a directory`) when picking a Live Photo from the iOS gallery. Live Photos are saved by iOS as `.pvt` packages (directories), which `loadFileRepresentation(forTypeIdentifier: UTType.item...)` returned as-is; the still image contained in the package is now extracted instead.
+- Fixed `getDirectoryPath`, `pickFiles`, `pickFileAndDirectoryPaths`, and `saveFile` on macOS defaulting to the sandbox container's `Data` folder instead of the user's real home directory when no `initialDirectory` is provided and the app has App Sandbox enabled.
 
 ## 1.0.1
 
-- Fixed `getDirectoryPath`, `pickFiles`, `pickFileAndDirectoryPaths`, and `saveFile` on macOS defaulting to the sandbox container's `Data` folder instead of the user's real home directory when no `initialDirectory` is provided and the app has App Sandbox enabled.
 - Fixed `pickFileAndDirectoryPaths` never returning directories on iOS and macOS. It now calls the native combined file and directory picker instead of silently falling back to file only selection.
 - Fixed `MissingPluginException` on macOS by registering the event channel stream handler.
 - Fixed method channel handling on macOS to support all file types and actions (`any`, `image`, `video`, `audio`, `media`, `custom`, `dir`, `save`).

--- a/packages/file_picker_darwin/CHANGELOG.md
+++ b/packages/file_picker_darwin/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 1.0.1
 
+- Fixed `getDirectoryPath`, `pickFiles`, `pickFileAndDirectoryPaths`, and `saveFile` on macOS defaulting to the sandbox container's `Data` folder instead of the user's real home directory when no `initialDirectory` is provided and the app has App Sandbox enabled.
 - Fixed `pickFileAndDirectoryPaths` never returning directories on iOS and macOS. It now calls the native combined file and directory picker instead of silently falling back to file only selection.
 - Fixed `MissingPluginException` on macOS by registering the event channel stream handler.
 - Fixed method channel handling on macOS to support all file types and actions (`any`, `image`, `video`, `audio`, `media`, `custom`, `dir`, `save`).

--- a/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/MacOSFilePickerHandler.swift
+++ b/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/MacOSFilePickerHandler.swift
@@ -13,6 +13,8 @@ private extension CFString {
         "com.apple.security.files.user-selected.read-only" as CFString
     static let securityFilesUserSelectedReadWrite =
         "com.apple.security.files.user-selected.read-write" as CFString
+    static let securityAppSandbox =
+        "com.apple.security.app-sandbox" as CFString
 }
 
 final class MacOSFilePickerHandler: NSObject, FlutterStreamHandler {
@@ -75,6 +77,8 @@ final class MacOSFilePickerHandler: NSObject, FlutterStreamHandler {
         if let initialDirectory = args["initialDirectory"] as? String,
            !initialDirectory.isEmpty {
             dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
+        } else if let fallbackDirectory = defaultDirectoryURL() {
+            dialog.directoryURL = fallbackDirectory
         }
         if let title = args["dialogTitle"] as? String {
             dialog.title = title
@@ -133,6 +137,8 @@ final class MacOSFilePickerHandler: NSObject, FlutterStreamHandler {
         if let initialDirectory = args["initialDirectory"] as? String,
            !initialDirectory.isEmpty {
             dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
+        } else if let fallbackDirectory = defaultDirectoryURL() {
+            dialog.directoryURL = fallbackDirectory
         }
         if let title = args["dialogTitle"] as? String {
             dialog.title = title
@@ -182,6 +188,8 @@ final class MacOSFilePickerHandler: NSObject, FlutterStreamHandler {
         if let initialDirectory = args["initialDirectory"] as? String,
            !initialDirectory.isEmpty {
             dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
+        } else if let fallbackDirectory = defaultDirectoryURL() {
+            dialog.directoryURL = fallbackDirectory
         }
         if let title = args["dialogTitle"] as? String {
             dialog.title = title
@@ -236,6 +244,8 @@ final class MacOSFilePickerHandler: NSObject, FlutterStreamHandler {
         if let initialDirectory = args["initialDirectory"] as? String,
            !initialDirectory.isEmpty {
             dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
+        } else if let fallbackDirectory = defaultDirectoryURL() {
+            dialog.directoryURL = fallbackDirectory
         }
 
         let extensions = args["allowedExtensions"] as? [String] ?? []
@@ -303,6 +313,17 @@ final class MacOSFilePickerHandler: NSObject, FlutterStreamHandler {
             }
         }
         return nil
+    }
+
+    private func isSandboxed() -> Bool {
+        guard let task = SecTaskCreateFromSelf(nil) else {
+            return false
+        }
+        return (SecTaskCopyValueForEntitlement(task, .securityAppSandbox, nil) as? Bool) == true
+    }
+
+    private func defaultDirectoryURL() -> URL? {
+        isSandboxed() ? FileManager.default.homeDirectoryForCurrentUser : nil
     }
 
     private func applyExtensions(_ dialog: NSSavePanel, _ extensions: [String], method: String = "") {


### PR DESCRIPTION
## Summary
- On macOS, when `initialDirectory` is not provided, `NSOpenPanel`/`NSSavePanel` default to the App Sandbox container's `Data` folder rather than the user's real home directory.
- This adds a sandbox entitlement check (`com.apple.security.app-sandbox`) and only when the app is sandboxed, falls back to `FileManager.default.homeDirectoryForCurrentUser` for `pickFiles`, `pickFileAndDirectoryPaths`, `getDirectoryPath`, and `saveFile`.
- Non-sandboxed apps are unaffected, they keep the panel's normal behavior of remembering the last visited directory.

Fixes #1542

## Test plan
- [x] `swift build` succeeds for `file_picker_darwin`
- [ ] Manual verification with the example app on macOS with App Sandbox enabled and no `initialDirectory` passed