### PR TITLE
Fix allowedExtensions discarded entirely when one extension has no known mime type

### DIFF
--- a/packages/file_picker_android/CHANGELOG.md
+++ b/packages/file_picker_android/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.2
 
 - Removed the stale `buildscript` classpath from the Android module, which pinned AGP 8.5.2 and Kotlin Gradle Plugin 1.8.22 in a module that supports AGP 9 and Kotlin 2.3. [#2154](https://github.com/miguelpruivo/flutter_file_picker/pull/2154)
+- Fixed `allowedExtensions` filters being discarded entirely and falling back to showing all files when only some of the requested extensions had no mime type known to Android (e.g. `pfx`, `p12`). Now the extensions that do resolve to a mime type are still used to filter, and `*/*` is only used when none of them resolve.
 
 ## 1.0.1
 

--- a/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -542,9 +542,9 @@ object FileUtils {
             if (mime == null) {
                 Log.w(
                     TAG,
-                    "Custom file type '" + allowedExtensions[i] + "' is unsupported and will not be filtered."
+                    "Custom file type '" + allowedExtensions[i] + "' has no known mime type and will not be filtered by the system picker."
                 )
-                return ArrayList(listOf("*/*"))
+                continue
             }
 
             mimes.add(mime)
@@ -553,6 +553,15 @@ object FileUtils {
                 mimes.add(CSV_MIME_TYPE)
             }
         }
+
+        if (mimes.isEmpty()) {
+            Log.w(
+                TAG,
+                "None of the custom file types $allowedExtensions have a known mime type, falling back to */*."
+            )
+            return ArrayList(listOf("*/*"))
+        }
+
         Log.d(
             TAG,
             "Custom file types are $allowedExtensions. The mime types were detected as $mimes."


### PR DESCRIPTION
## Summary
- `FileUtils.getMimeTypes` on Android returned `*/*` (no filtering at all) as soon as a single extension in `allowedExtensions` could not be resolved to a mime type via `MimeTypeMap` (e.g. `pfx`, `p12`, or `csv` on some OEM mime tables).
- This meant that even when other extensions in the same request did resolve fine, the whole filter was dropped and every file on the device was shown, matching the "allowedExtensions ignored" reports on physical Android 13 devices.
- Now unresolved extensions are skipped individually (with a warning logged) while resolved ones still filter the picker. `*/*` is only used when none of the requested extensions resolve.

Fixes #1717

## Test plan
- [ ] Manual verification with the example app using `allowedExtensions: ['pfx', 'p12']` and `allowedExtensions: ['csv', 'txt']` on a physical Android 13+ device
- No existing unit tests cover this function; none were added since there is no Kotlin unit test harness in this package yet