### PR TITLE
Fix window focus listener leak in web file picker

### DIFF
--- a/packages/file_picker_web/CHANGELOG.md
+++ b/packages/file_picker_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.2
+
+- Fixed the `window` `focus` listener used to detect a cancelled picker dialog never being removed after use. `removeEventListener` was passed a freshly created `.toJS` function object on every call, which never matches the one originally passed to `addEventListener`, so the listener leaked on `window` on every `pickFiles`/`pickFile` call. The JS function references are now cached and reused for both add and remove.
+
 ## 3.0.1
 
 - Improved package description, added example, and added missing API documentation.

--- a/packages/file_picker_web/lib/src/web_file_input_session.dart
+++ b/packages/file_picker_web/lib/src/web_file_input_session.dart
@@ -51,6 +51,13 @@ class WebFileInputSession {
   final Completer<List<PlatformFile>?> _completer = Completer();
   bool _eventTriggered = false;
 
+  // Cached once and reused for both addEventListener and removeEventListener.
+  // Function.toJS creates a new JS function object on every call, so passing
+  // freshly-created ones to removeEventListener would never actually match
+  // the listener added earlier, silently leaving it attached forever.
+  late final JSFunction _onFileSelectionListener = _onFileSelection.toJS;
+  late final JSFunction _onCancelListener = _onCancel.toJS;
+
   /// Starts the file picker input interaction and returns a list of picked files or `null`.
   Future<List<PlatformFile>?> start() async {
     final uploadInput = HTMLInputElement()
@@ -62,11 +69,11 @@ class WebFileInputSession {
 
     onFileLoading?.call(FilePickerStatus.picking);
 
-    uploadInput.addEventListener('change', _onFileSelection.toJS);
-    uploadInput.addEventListener('cancel', _onCancel.toJS);
+    uploadInput.addEventListener('change', _onFileSelectionListener);
+    uploadInput.addEventListener('cancel', _onCancelListener);
 
     if (webOptions.cancelUploadOnWindowBlur) {
-      window.addEventListener('focus', _onCancel.toJS);
+      window.addEventListener('focus', _onCancelListener);
     }
 
     _clearTargetChildren();
@@ -114,10 +121,10 @@ class WebFileInputSession {
   }
 
   void _cleanupListeners(HTMLInputElement? input) {
-    window.removeEventListener('focus', _onCancel.toJS);
+    window.removeEventListener('focus', _onCancelListener);
     if (input != null) {
-      input.removeEventListener('change', _onFileSelection.toJS);
-      input.removeEventListener('cancel', _onCancel.toJS);
+      input.removeEventListener('change', _onFileSelectionListener);
+      input.removeEventListener('cancel', _onCancelListener);
     }
   }
 

--- a/packages/file_picker_web/pubspec.yaml
+++ b/packages/file_picker_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_picker_web
 description: Web platform implementation of the file_picker plugin, providing browser file selection, file streaming, and file loading.
-version: 3.0.1
+version: 3.0.2
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_web
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_web
 topics:


### PR DESCRIPTION
## Summary
- `WebFileInputSession._cleanupListeners` called `window.removeEventListener('focus', _onCancel.toJS)`, but `Function.toJS` returns a new JS function object on every call, it is never the same object passed to `addEventListener` earlier.
- `removeEventListener` matches by function identity, so this removal was a silent no-op. Every `pickFiles`/`pickFile` call on web (with the default `cancelUploadOnWindowBlur: true`) permanently left a `focus` listener attached to `window`, accumulating indefinitely across repeated picker usage.
- The JS function references for `_onFileSelection` and `_onCancel` are now created once per session and reused for both `addEventListener` and `removeEventListener`.

Relates to #1687 (the original "pickFiles never resolves" hang described there looks already mitigated by the existing `_eventTriggered` guard and 500ms re-check in `_onCancel`, this PR addresses the listener leak that was also flagged in that thread).

## Test plan
- [x] `dart analyze` passes on the modified file
- [ ] Manual check on Chrome devtools: inspect `getEventListeners(window)` before/after several `pickFiles()` calls to confirm listener count no longer grows