### PR TITLE
Hide file extension by default in macOS Save dialog

### DIFF
--- a/packages/file_picker_darwin/CHANGELOG.md
+++ b/packages/file_picker_darwin/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fixed a crash (`FileSystemException`/`OSError: Is a directory`) when picking a Live Photo from the iOS gallery. Live Photos are saved by iOS as `.pvt` packages (directories), which `loadFileRepresentation(forTypeIdentifier: UTType.item...)` returned as-is; the still image contained in the package is now extracted instead.
 - Fixed `getDirectoryPath`, `pickFiles`, `pickFileAndDirectoryPaths`, and `saveFile` on macOS defaulting to the sandbox container's `Data` folder instead of the user's real home directory when no `initialDirectory` is provided and the app has App Sandbox enabled.
+- Fixed the Save dialog on macOS auto-selecting the file extension along with the rest of the file name, making it easy to accidentally delete the extension when renaming. The extension is now hidden by default via `NSSavePanel.isExtensionHidden`.
 
 ## 1.0.1
 

--- a/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/MacOSFilePickerHandler.swift
+++ b/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/MacOSFilePickerHandler.swift
@@ -239,6 +239,7 @@ final class MacOSFilePickerHandler: NSObject, FlutterStreamHandler {
         dialog.showsTagField = false
         dialog.showsHiddenFiles = false
         dialog.canCreateDirectories = true
+        dialog.isExtensionHidden = true
         dialog.nameFieldStringValue = args["fileName"] as? String ?? ""
 
         if let initialDirectory = args["initialDirectory"] as? String,


### PR DESCRIPTION
## Summary
- On macOS, `NSSavePanel` selects the entire suggested file name including its extension when the name field becomes editable, so users renaming the file before saving often delete the extension without noticing.
- Sets `dialog.isExtensionHidden = true` in `handleSaveFile`, matching what was already suggested in the issue thread.
- Note this does not fully close the door on the user removing the extension, they can still reveal and edit it via the panel's own toggle. That is a known limitation of `NSSavePanel` itself, not something the plugin can fully control.

Fixes #1740

## Test plan
- [x] `swift build` succeeds for `file_picker_darwin`
- [ ] Manual verification with the example app on macOS: trigger saveFile and confirm the extension is hidden and not part of the initial selection