### PR TITLE
Treat bundle-like directories as selectable files on macOS

### DIFF
--- a/packages/file_picker_darwin/CHANGELOG.md
+++ b/packages/file_picker_darwin/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed a crash (`FileSystemException`/`OSError: Is a directory`) when picking a Live Photo from the iOS gallery. Live Photos are saved by iOS as `.pvt` packages (directories), which `loadFileRepresentation(forTypeIdentifier: UTType.item...)` returned as-is; the still image contained in the package is now extracted instead.
 - Fixed `getDirectoryPath`, `pickFiles`, `pickFileAndDirectoryPaths`, and `saveFile` on macOS defaulting to the sandbox container's `Data` folder instead of the user's real home directory when no `initialDirectory` is provided and the app has App Sandbox enabled.
 - Fixed the Save dialog on macOS auto-selecting the file extension along with the rest of the file name, making it easy to accidentally delete the extension when renaming. The extension is now hidden by default via `NSSavePanel.isExtensionHidden`.
+- Fixed bundle-like directories (e.g. `.app`, `.fcpbundle`) not being selectable as files on macOS file pickers, a regression since 8.2.0. `NSOpenPanel.treatsFilePackagesAsDirectories` is now explicitly set to `false` so these are presented as selectable files, matching Finder and other native apps.
 
 ## 1.0.1
 

--- a/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/MacOSFilePickerHandler.swift
+++ b/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/MacOSFilePickerHandler.swift
@@ -89,6 +89,9 @@ final class MacOSFilePickerHandler: NSObject, FlutterStreamHandler {
         dialog.allowsMultipleSelection = allowMultiple
         dialog.canChooseDirectories = false
         dialog.canChooseFiles = true
+        // Bundle-like directories (e.g. .app, .fcpbundle) should be selectable
+        // as files, matching how Finder and other native apps present them.
+        dialog.treatsFilePackagesAsDirectories = false
         let extensions = args["allowedExtensions"] as? [String] ?? []
         applyExtensions(dialog, extensions, method: call.method)
 
@@ -148,6 +151,9 @@ final class MacOSFilePickerHandler: NSObject, FlutterStreamHandler {
         dialog.allowsMultipleSelection = true
         dialog.canChooseDirectories = true
         dialog.canChooseFiles = true
+        // Bundle-like directories (e.g. .app, .fcpbundle) should be selectable
+        // as files, matching how Finder and other native apps present them.
+        dialog.treatsFilePackagesAsDirectories = false
         let extensions = args["allowedExtensions"] as? [String] ?? []
         applyExtensions(dialog, extensions, method: call.method)
 


### PR DESCRIPTION
## Summary
- On macOS, bundle-like directories (e.g. `.fcpbundle`, `.app`) are folders on disk but are presented as single selectable files by Finder and most native apps.
- The plugin never set `NSOpenPanel.treatsFilePackagesAsDirectories`, so this relied entirely on system defaults, which apparently changed since 8.2.0 and made these no longer selectable via `allowedExtensions`.
- Explicitly sets `treatsFilePackagesAsDirectories = false` in `handleFileSelection` and `handleFileAndDirectorySelection`, so packages are always presented as selectable files regardless of OS version.

Fixes #1787
Fixes #1912

## Test plan
- [x] `swift build` succeeds for `file_picker_darwin`
- [ ] Manual verification with the example app on macOS: pick a `.fcpbundle` or `.app` with `allowedExtensions` and confirm it is selectable as a file instead of being navigated into