### PR TITLE
Fix brief UI freeze on macOS by moving the entitlement check off the main thread

### DIFF
--- a/packages/file_picker_darwin/CHANGELOG.md
+++ b/packages/file_picker_darwin/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed `saveFile` on macOS never enforcing an extension on the destination file when the user cleared it from the suggested name. `allowedExtensions` is not forwarded to `saveFile` yet, so the dialog now falls back to the extension of the suggested file name.
 - Fixed `saveFile` returning a scheme-less, percent-encoded `Uri` on macOS instead of a proper `file://` Uri, unlike Windows and Linux.
 - Added `FilePickerDarwin.skipEntitlementsChecks()`, letting non-sandboxed macOS apps opt out of the App Sandbox entitlement checks performed before showing a dialog. This was previously only reachable through a deprecated, no-op method on `FilePicker` in the root package.
+- Fixed a brief UI freeze on macOS right when calling `pickFiles`, `pickFileAndDirectoryPaths`, `getDirectoryPath`, or `saveFile`. The entitlement check now runs on a background queue before the dialog is created, instead of blocking the main thread synchronously.
 
 ## 1.0.1
 

--- a/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/MacOSFilePickerHandler.swift
+++ b/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/MacOSFilePickerHandler.swift
@@ -63,71 +63,86 @@ final class MacOSFilePickerHandler: NSObject, FlutterStreamHandler {
         }
     }
 
-    private func handleFileSelection(
-        _ call: FlutterMethodCall,
-        result: @escaping FlutterResult
+    /// Runs `checkEntitlement` on a background queue (Security framework calls are
+    /// synchronous and were causing a brief main-thread stall), then hops back to the
+    /// main queue: either delivering the entitlement error, or calling
+    /// `onEntitlementGranted` to build and present the dialog.
+    private func withEntitlementCheck(
+        requiredMode: EntitlementMode,
+        result: @escaping FlutterResult,
+        onEntitlementGranted: @escaping () -> Void
     ) {
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { return }
-            let entitlementError = self.checkEntitlement(requiredMode: .readOrWrite)
+            let entitlementError = self.checkEntitlement(requiredMode: requiredMode)
 
             DispatchQueue.main.async {
                 if let entitlementError {
                     result(entitlementError)
                     return
                 }
+                onEntitlementGranted()
+            }
+        }
+    }
 
-                let dialog = NSOpenPanel()
-                let args = (call.arguments as? [String: Any]) ?? [:]
+    private func handleFileSelection(
+        _ call: FlutterMethodCall,
+        result: @escaping FlutterResult
+    ) {
+        withEntitlementCheck(requiredMode: .readOrWrite, result: result) { [weak self] in
+            guard let self else { return }
 
-                if let initialDirectory = args["initialDirectory"] as? String,
-                   !initialDirectory.isEmpty {
-                    dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
-                } else if let fallbackDirectory = self.defaultDirectoryURL() {
-                    dialog.directoryURL = fallbackDirectory
-                }
-                if let title = args["dialogTitle"] as? String {
-                    dialog.title = title
-                    dialog.message = title
-                }
-                dialog.showsHiddenFiles = false
-                let allowMultiple = (args["allowMultipleSelection"] as? Bool) ?? (args["allowMultiple"] as? Bool) ?? false
-                dialog.allowsMultipleSelection = allowMultiple
-                dialog.canChooseDirectories = false
-                dialog.canChooseFiles = true
-                // Bundle-like directories (e.g. .app, .fcpbundle) should be selectable
-                // as files, matching how Finder and other native apps present them.
-                dialog.treatsFilePackagesAsDirectories = false
-                let extensions = args["allowedExtensions"] as? [String] ?? []
-                self.applyExtensions(dialog, extensions, method: call.method)
+            let dialog = NSOpenPanel()
+            let args = (call.arguments as? [String: Any]) ?? [:]
 
-                guard let appWindow = self.getFlutterWindow() else {
+            if let initialDirectory = args["initialDirectory"] as? String,
+               !initialDirectory.isEmpty {
+                dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
+            } else if let fallbackDirectory = self.defaultDirectoryURL() {
+                dialog.directoryURL = fallbackDirectory
+            }
+            if let title = args["dialogTitle"] as? String {
+                dialog.title = title
+                dialog.message = title
+            }
+            dialog.showsHiddenFiles = false
+            let allowMultiple = (args["allowMultipleSelection"] as? Bool) ?? (args["allowMultiple"] as? Bool) ?? false
+            dialog.allowsMultipleSelection = allowMultiple
+            dialog.canChooseDirectories = false
+            dialog.canChooseFiles = true
+            // Bundle-like directories (e.g. .app, .fcpbundle) should be selectable
+            // as files, matching how Finder and other native apps present them.
+            dialog.treatsFilePackagesAsDirectories = false
+            let extensions = args["allowedExtensions"] as? [String] ?? []
+            self.applyExtensions(dialog, extensions, method: call.method)
+
+            guard let appWindow = self.getFlutterWindow() else {
+                result(nil)
+                return
+            }
+
+            dialog.beginSheetModal(for: appWindow) { response in
+                if response != .OK {
                     result(nil)
                     return
                 }
 
-                dialog.beginSheetModal(for: appWindow) { response in
-                    if response != .OK {
-                        result(nil)
-                        return
-                    }
+                let fileMaps = dialog.urls.compactMap { url -> [String: Any]? in
+                    let path = url.path
+                    let name = url.lastPathComponent
+                    let size = (try? FileManager.default.attributesOfItem(atPath: path)[.size] as? Int64) ?? 0
+                    return [
+                        "path": path,
+                        "name": name,
+                        "size": size
+                    ]
+                }
 
-                    let fileMaps = dialog.urls.compactMap { url -> [String: Any]? in
-                        let path = url.path
-                        let name = url.lastPathComponent
-                        let size = (try? FileManager.default.attributesOfItem(atPath: path)[.size] as? Int64) ?? 0
-                        return [
-                            "path": path,
-                            "name": name,
-                            "size": size
-                        ]
-                    }
-
-                    if fileMaps.isEmpty {
-                        result(nil)
-                    } else {
-                        result(fileMaps)
-                    }
+                if fileMaps.isEmpty {
+                    result(nil)
+                } else {
+                    result(fileMaps)
                 }
             }
         }
@@ -137,58 +152,50 @@ final class MacOSFilePickerHandler: NSObject, FlutterStreamHandler {
         _ call: FlutterMethodCall,
         result: @escaping FlutterResult
     ) {
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+        withEntitlementCheck(requiredMode: .readOrWrite, result: result) { [weak self] in
             guard let self else { return }
-            let entitlementError = self.checkEntitlement(requiredMode: .readOrWrite)
 
-            DispatchQueue.main.async {
-                if let entitlementError {
-                    result(entitlementError)
-                    return
-                }
+            let dialog: NSOpenPanel = NSOpenPanel()
+            let args = (call.arguments as? [String: Any]) ?? [:]
 
-                let dialog: NSOpenPanel = NSOpenPanel()
-                let args = (call.arguments as? [String: Any]) ?? [:]
+            if let initialDirectory = args["initialDirectory"] as? String,
+               !initialDirectory.isEmpty {
+                dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
+            } else if let fallbackDirectory = self.defaultDirectoryURL() {
+                dialog.directoryURL = fallbackDirectory
+            }
+            if let title = args["dialogTitle"] as? String {
+                dialog.title = title
+                dialog.message = title
+            }
+            dialog.showsHiddenFiles = false
+            dialog.allowsMultipleSelection = true
+            dialog.canChooseDirectories = true
+            dialog.canChooseFiles = true
+            // Bundle-like directories (e.g. .app, .fcpbundle) should be selectable
+            // as files, matching how Finder and other native apps present them.
+            dialog.treatsFilePackagesAsDirectories = false
+            let extensions = args["allowedExtensions"] as? [String] ?? []
+            self.applyExtensions(dialog, extensions, method: call.method)
 
-                if let initialDirectory = args["initialDirectory"] as? String,
-                   !initialDirectory.isEmpty {
-                    dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
-                } else if let fallbackDirectory = self.defaultDirectoryURL() {
-                    dialog.directoryURL = fallbackDirectory
-                }
-                if let title = args["dialogTitle"] as? String {
-                    dialog.title = title
-                    dialog.message = title
-                }
-                dialog.showsHiddenFiles = false
-                dialog.allowsMultipleSelection = true
-                dialog.canChooseDirectories = true
-                dialog.canChooseFiles = true
-                // Bundle-like directories (e.g. .app, .fcpbundle) should be selectable
-                // as files, matching how Finder and other native apps present them.
-                dialog.treatsFilePackagesAsDirectories = false
-                let extensions = args["allowedExtensions"] as? [String] ?? []
-                self.applyExtensions(dialog, extensions, method: call.method)
+            guard let appWindow: NSWindow = self.getFlutterWindow() else {
+                result(nil)
+                return
+            }
 
-                guard let appWindow: NSWindow = self.getFlutterWindow() else {
+            dialog.beginSheetModal(for: appWindow) { response in
+                if response != .OK {
                     result(nil)
                     return
                 }
 
-                dialog.beginSheetModal(for: appWindow) { response in
-                    if response != .OK {
-                        result(nil)
-                        return
-                    }
+                let pathResult = dialog.urls
 
-                    let pathResult = dialog.urls
-
-                    if pathResult.isEmpty {
-                        result(nil)
-                    } else {
-                        let paths = pathResult.map { $0.path }
-                        result(paths)
-                    }
+                if pathResult.isEmpty {
+                    result(nil)
+                } else {
+                    let paths = pathResult.map { $0.path }
+                    result(paths)
                 }
             }
         }
@@ -198,55 +205,47 @@ final class MacOSFilePickerHandler: NSObject, FlutterStreamHandler {
         _ call: FlutterMethodCall,
         result: @escaping FlutterResult
     ) {
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+        withEntitlementCheck(requiredMode: .readOrWrite, result: result) { [weak self] in
             guard let self else { return }
-            let entitlementError = self.checkEntitlement(requiredMode: .readOrWrite)
 
-            DispatchQueue.main.async {
-                if let entitlementError {
-                    result(entitlementError)
-                    return
+            let dialog = NSOpenPanel()
+            let args = (call.arguments as? [String: Any]) ?? [:]
+
+            if let initialDirectory = args["initialDirectory"] as? String,
+               !initialDirectory.isEmpty {
+                dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
+            } else if let fallbackDirectory = self.defaultDirectoryURL() {
+                dialog.directoryURL = fallbackDirectory
+            }
+            if let title = args["dialogTitle"] as? String {
+                dialog.title = title
+                if #available(macOS 10.10, *) {
+                    dialog.titleVisibility = .visible
+                    dialog.titlebarAppearsTransparent = false
                 }
+                dialog.message = title
+            }
+            dialog.showsHiddenFiles = false
+            dialog.allowsMultipleSelection = false
+            dialog.canChooseDirectories = true
+            dialog.canChooseFiles = false
 
-                let dialog = NSOpenPanel()
-                let args = (call.arguments as? [String: Any]) ?? [:]
-
-                if let initialDirectory = args["initialDirectory"] as? String,
-                   !initialDirectory.isEmpty {
-                    dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
-                } else if let fallbackDirectory = self.defaultDirectoryURL() {
-                    dialog.directoryURL = fallbackDirectory
-                }
-                if let title = args["dialogTitle"] as? String {
-                    dialog.title = title
-                    if #available(macOS 10.10, *) {
-                        dialog.titleVisibility = .visible
-                        dialog.titlebarAppearsTransparent = false
-                    }
-                    dialog.message = title
-                }
-                dialog.showsHiddenFiles = false
-                dialog.allowsMultipleSelection = false
-                dialog.canChooseDirectories = true
-                dialog.canChooseFiles = false
-
-                guard let appWindow = self.getFlutterWindow() else {
+            guard let appWindow = self.getFlutterWindow() else {
+                result(nil)
+                return
+            }
+            dialog.beginSheetModal(for: appWindow) { response in
+                if response != .OK {
                     result(nil)
                     return
                 }
-                dialog.beginSheetModal(for: appWindow) { response in
-                    if response != .OK {
-                        result(nil)
-                        return
-                    }
 
-                    if let url = dialog.url {
-                        result(url.path)
-                        return
-                    }
-
-                    result(nil)
+                if let url = dialog.url {
+                    result(url.path)
+                    return
                 }
+
+                result(nil)
             }
         }
     }
@@ -255,56 +254,48 @@ final class MacOSFilePickerHandler: NSObject, FlutterStreamHandler {
         _ call: FlutterMethodCall,
         result: @escaping FlutterResult
     ) {
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+        withEntitlementCheck(requiredMode: .requireWrite, result: result) { [weak self] in
             guard let self else { return }
-            let entitlementError = self.checkEntitlement(requiredMode: .requireWrite)
 
-            DispatchQueue.main.async {
-                if let entitlementError {
-                    result(entitlementError)
-                    return
-                }
+            let dialog = NSSavePanel()
+            let args = (call.arguments as? [String: Any]) ?? [:]
 
-                let dialog = NSSavePanel()
-                let args = (call.arguments as? [String: Any]) ?? [:]
+            dialog.title = args["dialogTitle"] as? String ?? ""
+            dialog.showsTagField = false
+            dialog.showsHiddenFiles = false
+            dialog.canCreateDirectories = true
+            dialog.isExtensionHidden = true
+            dialog.nameFieldStringValue = args["fileName"] as? String ?? ""
 
-                dialog.title = args["dialogTitle"] as? String ?? ""
-                dialog.showsTagField = false
-                dialog.showsHiddenFiles = false
-                dialog.canCreateDirectories = true
-                dialog.isExtensionHidden = true
-                dialog.nameFieldStringValue = args["fileName"] as? String ?? ""
+            if let initialDirectory = args["initialDirectory"] as? String,
+               !initialDirectory.isEmpty {
+                dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
+            } else if let fallbackDirectory = self.defaultDirectoryURL() {
+                dialog.directoryURL = fallbackDirectory
+            }
 
-                if let initialDirectory = args["initialDirectory"] as? String,
-                   !initialDirectory.isEmpty {
-                    dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
-                } else if let fallbackDirectory = self.defaultDirectoryURL() {
-                    dialog.directoryURL = fallbackDirectory
-                }
+            let extensions = args["allowedExtensions"] as? [String] ?? []
+            self.applyExtensions(dialog, extensions, method: call.method)
+            if extensions.isEmpty {
+                self.applyDefaultExtension(dialog, fileName: args["fileName"] as? String ?? "")
+            }
 
-                let extensions = args["allowedExtensions"] as? [String] ?? []
-                self.applyExtensions(dialog, extensions, method: call.method)
-                if extensions.isEmpty {
-                    self.applyDefaultExtension(dialog, fileName: args["fileName"] as? String ?? "")
-                }
-
-                guard let appWindow = self.getFlutterWindow() else {
+            guard let appWindow = self.getFlutterWindow() else {
+                result(nil)
+                return
+            }
+            dialog.beginSheetModal(for: appWindow) { response in
+                if response != .OK {
                     result(nil)
                     return
                 }
-                dialog.beginSheetModal(for: appWindow) { response in
-                    if response != .OK {
-                        result(nil)
-                        return
-                    }
 
-                    if let url = dialog.url {
-                        result(url.path)
-                        return
-                    }
-
-                    result(nil)
+                if let url = dialog.url {
+                    result(url.path)
+                    return
                 }
+
+                result(nil)
             }
         }
     }

--- a/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/MacOSFilePickerHandler.swift
+++ b/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/MacOSFilePickerHandler.swift
@@ -67,60 +67,68 @@ final class MacOSFilePickerHandler: NSObject, FlutterStreamHandler {
         _ call: FlutterMethodCall,
         result: @escaping FlutterResult
     ) {
-        if let entitlementError = checkEntitlement(requiredMode: .readOrWrite) {
-            result(entitlementError)
-            return
-        }
-        let dialog = NSOpenPanel()
-        let args = (call.arguments as? [String: Any]) ?? [:]
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self else { return }
+            let entitlementError = self.checkEntitlement(requiredMode: .readOrWrite)
 
-        if let initialDirectory = args["initialDirectory"] as? String,
-           !initialDirectory.isEmpty {
-            dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
-        } else if let fallbackDirectory = defaultDirectoryURL() {
-            dialog.directoryURL = fallbackDirectory
-        }
-        if let title = args["dialogTitle"] as? String {
-            dialog.title = title
-            dialog.message = title
-        }
-        dialog.showsHiddenFiles = false
-        let allowMultiple = (args["allowMultipleSelection"] as? Bool) ?? (args["allowMultiple"] as? Bool) ?? false
-        dialog.allowsMultipleSelection = allowMultiple
-        dialog.canChooseDirectories = false
-        dialog.canChooseFiles = true
-        // Bundle-like directories (e.g. .app, .fcpbundle) should be selectable
-        // as files, matching how Finder and other native apps present them.
-        dialog.treatsFilePackagesAsDirectories = false
-        let extensions = args["allowedExtensions"] as? [String] ?? []
-        applyExtensions(dialog, extensions, method: call.method)
+            DispatchQueue.main.async {
+                if let entitlementError {
+                    result(entitlementError)
+                    return
+                }
 
-        guard let appWindow = getFlutterWindow() else {
-            result(nil)
-            return
-        }
+                let dialog = NSOpenPanel()
+                let args = (call.arguments as? [String: Any]) ?? [:]
 
-        dialog.beginSheetModal(for: appWindow) { response in
-            if response != .OK {
-                result(nil)
-                return
-            }
+                if let initialDirectory = args["initialDirectory"] as? String,
+                   !initialDirectory.isEmpty {
+                    dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
+                } else if let fallbackDirectory = self.defaultDirectoryURL() {
+                    dialog.directoryURL = fallbackDirectory
+                }
+                if let title = args["dialogTitle"] as? String {
+                    dialog.title = title
+                    dialog.message = title
+                }
+                dialog.showsHiddenFiles = false
+                let allowMultiple = (args["allowMultipleSelection"] as? Bool) ?? (args["allowMultiple"] as? Bool) ?? false
+                dialog.allowsMultipleSelection = allowMultiple
+                dialog.canChooseDirectories = false
+                dialog.canChooseFiles = true
+                // Bundle-like directories (e.g. .app, .fcpbundle) should be selectable
+                // as files, matching how Finder and other native apps present them.
+                dialog.treatsFilePackagesAsDirectories = false
+                let extensions = args["allowedExtensions"] as? [String] ?? []
+                self.applyExtensions(dialog, extensions, method: call.method)
 
-            let fileMaps = dialog.urls.compactMap { url -> [String: Any]? in
-                let path = url.path
-                let name = url.lastPathComponent
-                let size = (try? FileManager.default.attributesOfItem(atPath: path)[.size] as? Int64) ?? 0
-                return [
-                    "path": path,
-                    "name": name,
-                    "size": size
-                ]
-            }
+                guard let appWindow = self.getFlutterWindow() else {
+                    result(nil)
+                    return
+                }
 
-            if fileMaps.isEmpty {
-                result(nil)
-            } else {
-                result(fileMaps)
+                dialog.beginSheetModal(for: appWindow) { response in
+                    if response != .OK {
+                        result(nil)
+                        return
+                    }
+
+                    let fileMaps = dialog.urls.compactMap { url -> [String: Any]? in
+                        let path = url.path
+                        let name = url.lastPathComponent
+                        let size = (try? FileManager.default.attributesOfItem(atPath: path)[.size] as? Int64) ?? 0
+                        return [
+                            "path": path,
+                            "name": name,
+                            "size": size
+                        ]
+                    }
+
+                    if fileMaps.isEmpty {
+                        result(nil)
+                    } else {
+                        result(fileMaps)
+                    }
+                }
             }
         }
     }
@@ -129,52 +137,59 @@ final class MacOSFilePickerHandler: NSObject, FlutterStreamHandler {
         _ call: FlutterMethodCall,
         result: @escaping FlutterResult
     ) {
-        if let entitlementError = checkEntitlement(requiredMode: .readOrWrite) {
-            result(entitlementError)
-            return
-        }
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self else { return }
+            let entitlementError = self.checkEntitlement(requiredMode: .readOrWrite)
 
-        let dialog: NSOpenPanel = NSOpenPanel()
-        let args = (call.arguments as? [String: Any]) ?? [:]
+            DispatchQueue.main.async {
+                if let entitlementError {
+                    result(entitlementError)
+                    return
+                }
 
-        if let initialDirectory = args["initialDirectory"] as? String,
-           !initialDirectory.isEmpty {
-            dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
-        } else if let fallbackDirectory = defaultDirectoryURL() {
-            dialog.directoryURL = fallbackDirectory
-        }
-        if let title = args["dialogTitle"] as? String {
-            dialog.title = title
-            dialog.message = title
-        }
-        dialog.showsHiddenFiles = false
-        dialog.allowsMultipleSelection = true
-        dialog.canChooseDirectories = true
-        dialog.canChooseFiles = true
-        // Bundle-like directories (e.g. .app, .fcpbundle) should be selectable
-        // as files, matching how Finder and other native apps present them.
-        dialog.treatsFilePackagesAsDirectories = false
-        let extensions = args["allowedExtensions"] as? [String] ?? []
-        applyExtensions(dialog, extensions, method: call.method)
+                let dialog: NSOpenPanel = NSOpenPanel()
+                let args = (call.arguments as? [String: Any]) ?? [:]
 
-        guard let appWindow: NSWindow = getFlutterWindow() else {
-            result(nil)
-            return
-        }
+                if let initialDirectory = args["initialDirectory"] as? String,
+                   !initialDirectory.isEmpty {
+                    dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
+                } else if let fallbackDirectory = self.defaultDirectoryURL() {
+                    dialog.directoryURL = fallbackDirectory
+                }
+                if let title = args["dialogTitle"] as? String {
+                    dialog.title = title
+                    dialog.message = title
+                }
+                dialog.showsHiddenFiles = false
+                dialog.allowsMultipleSelection = true
+                dialog.canChooseDirectories = true
+                dialog.canChooseFiles = true
+                // Bundle-like directories (e.g. .app, .fcpbundle) should be selectable
+                // as files, matching how Finder and other native apps present them.
+                dialog.treatsFilePackagesAsDirectories = false
+                let extensions = args["allowedExtensions"] as? [String] ?? []
+                self.applyExtensions(dialog, extensions, method: call.method)
 
-        dialog.beginSheetModal(for: appWindow) { response in
-            if response != .OK {
-                result(nil)
-                return
-            }
+                guard let appWindow: NSWindow = self.getFlutterWindow() else {
+                    result(nil)
+                    return
+                }
 
-            let pathResult = dialog.urls
+                dialog.beginSheetModal(for: appWindow) { response in
+                    if response != .OK {
+                        result(nil)
+                        return
+                    }
 
-            if pathResult.isEmpty {
-                result(nil)
-            } else {
-                let paths = pathResult.map { $0.path }
-                result(paths)
+                    let pathResult = dialog.urls
+
+                    if pathResult.isEmpty {
+                        result(nil)
+                    } else {
+                        let paths = pathResult.map { $0.path }
+                        result(paths)
+                    }
+                }
             }
         }
     }
@@ -183,49 +198,56 @@ final class MacOSFilePickerHandler: NSObject, FlutterStreamHandler {
         _ call: FlutterMethodCall,
         result: @escaping FlutterResult
     ) {
-        if let entitlementError = checkEntitlement(requiredMode: .readOrWrite) {
-            result(entitlementError)
-            return
-        }
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self else { return }
+            let entitlementError = self.checkEntitlement(requiredMode: .readOrWrite)
 
-        let dialog = NSOpenPanel()
-        let args = (call.arguments as? [String: Any]) ?? [:]
+            DispatchQueue.main.async {
+                if let entitlementError {
+                    result(entitlementError)
+                    return
+                }
 
-        if let initialDirectory = args["initialDirectory"] as? String,
-           !initialDirectory.isEmpty {
-            dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
-        } else if let fallbackDirectory = defaultDirectoryURL() {
-            dialog.directoryURL = fallbackDirectory
-        }
-        if let title = args["dialogTitle"] as? String {
-            dialog.title = title
-            if #available(macOS 10.10, *) {
-                dialog.titleVisibility = .visible
-                dialog.titlebarAppearsTransparent = false
+                let dialog = NSOpenPanel()
+                let args = (call.arguments as? [String: Any]) ?? [:]
+
+                if let initialDirectory = args["initialDirectory"] as? String,
+                   !initialDirectory.isEmpty {
+                    dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
+                } else if let fallbackDirectory = self.defaultDirectoryURL() {
+                    dialog.directoryURL = fallbackDirectory
+                }
+                if let title = args["dialogTitle"] as? String {
+                    dialog.title = title
+                    if #available(macOS 10.10, *) {
+                        dialog.titleVisibility = .visible
+                        dialog.titlebarAppearsTransparent = false
+                    }
+                    dialog.message = title
+                }
+                dialog.showsHiddenFiles = false
+                dialog.allowsMultipleSelection = false
+                dialog.canChooseDirectories = true
+                dialog.canChooseFiles = false
+
+                guard let appWindow = self.getFlutterWindow() else {
+                    result(nil)
+                    return
+                }
+                dialog.beginSheetModal(for: appWindow) { response in
+                    if response != .OK {
+                        result(nil)
+                        return
+                    }
+
+                    if let url = dialog.url {
+                        result(url.path)
+                        return
+                    }
+
+                    result(nil)
+                }
             }
-            dialog.message = title
-        }
-        dialog.showsHiddenFiles = false
-        dialog.allowsMultipleSelection = false
-        dialog.canChooseDirectories = true
-        dialog.canChooseFiles = false
-
-        guard let appWindow = getFlutterWindow() else {
-            result(nil)
-            return
-        }
-        dialog.beginSheetModal(for: appWindow) { response in
-            if response != .OK {
-                result(nil)
-                return
-            }
-
-            if let url = dialog.url {
-                result(url.path)
-                return
-            }
-
-            result(nil)
         }
     }
 
@@ -233,50 +255,57 @@ final class MacOSFilePickerHandler: NSObject, FlutterStreamHandler {
         _ call: FlutterMethodCall,
         result: @escaping FlutterResult
     ) {
-        if let entitlementError = checkEntitlement(requiredMode: .requireWrite) {
-            result(entitlementError)
-            return
-        }
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self else { return }
+            let entitlementError = self.checkEntitlement(requiredMode: .requireWrite)
 
-        let dialog = NSSavePanel()
-        let args = (call.arguments as? [String: Any]) ?? [:]
+            DispatchQueue.main.async {
+                if let entitlementError {
+                    result(entitlementError)
+                    return
+                }
 
-        dialog.title = args["dialogTitle"] as? String ?? ""
-        dialog.showsTagField = false
-        dialog.showsHiddenFiles = false
-        dialog.canCreateDirectories = true
-        dialog.isExtensionHidden = true
-        dialog.nameFieldStringValue = args["fileName"] as? String ?? ""
+                let dialog = NSSavePanel()
+                let args = (call.arguments as? [String: Any]) ?? [:]
 
-        if let initialDirectory = args["initialDirectory"] as? String,
-           !initialDirectory.isEmpty {
-            dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
-        } else if let fallbackDirectory = defaultDirectoryURL() {
-            dialog.directoryURL = fallbackDirectory
-        }
+                dialog.title = args["dialogTitle"] as? String ?? ""
+                dialog.showsTagField = false
+                dialog.showsHiddenFiles = false
+                dialog.canCreateDirectories = true
+                dialog.isExtensionHidden = true
+                dialog.nameFieldStringValue = args["fileName"] as? String ?? ""
 
-        let extensions = args["allowedExtensions"] as? [String] ?? []
-        applyExtensions(dialog, extensions, method: call.method)
-        if extensions.isEmpty {
-            applyDefaultExtension(dialog, fileName: args["fileName"] as? String ?? "")
-        }
+                if let initialDirectory = args["initialDirectory"] as? String,
+                   !initialDirectory.isEmpty {
+                    dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
+                } else if let fallbackDirectory = self.defaultDirectoryURL() {
+                    dialog.directoryURL = fallbackDirectory
+                }
 
-        guard let appWindow = getFlutterWindow() else {
-            result(nil)
-            return
-        }
-        dialog.beginSheetModal(for: appWindow) { response in
-            if response != .OK {
-                result(nil)
-                return
+                let extensions = args["allowedExtensions"] as? [String] ?? []
+                self.applyExtensions(dialog, extensions, method: call.method)
+                if extensions.isEmpty {
+                    self.applyDefaultExtension(dialog, fileName: args["fileName"] as? String ?? "")
+                }
+
+                guard let appWindow = self.getFlutterWindow() else {
+                    result(nil)
+                    return
+                }
+                dialog.beginSheetModal(for: appWindow) { response in
+                    if response != .OK {
+                        result(nil)
+                        return
+                    }
+
+                    if let url = dialog.url {
+                        result(url.path)
+                        return
+                    }
+
+                    result(nil)
+                }
             }
-
-            if let url = dialog.url {
-                result(url.path)
-                return
-            }
-
-            result(nil)
         }
     }
 


### PR DESCRIPTION
## Summary
- `checkEntitlement` performed synchronous Security framework calls (`SecTaskCreateFromSelf` and two `SecTaskCopyValueForEntitlement` calls) on the main thread at the very top of `handleFileSelection`, `handleFileAndDirectorySelection`, `handleDirectorySelection`, and `handleSaveFile`, before any dialog was created.
- This caused a brief but noticeable UI freeze right when `pickFiles`, `pickFileAndDirectoryPaths`, `getDirectoryPath`, or `saveFile` were invoked, most visible as a stutter in any running animation.
- The entitlement check now runs on a background queue (`DispatchQueue.global(qos: .userInitiated)`) first, then hops back to `DispatchQueue.main.async` to build and present the dialog, same as before.
- Also relevant to #1704: since the dialog creation and `beginSheetModal` completion still run entirely on the main thread (just reached via `DispatchQueue.main.async` now instead of synchronously), there is no risk of the panel's result landing on a background thread.

Fixes #2056

## Test plan
- [x] `swift build` succeeds for `file_picker_darwin`
- [x] Manually verified with the example app using the exact freeze repro from the original issue thread (two spinning `CircularProgressIndicator`s around a button calling `pickFiles()`), no stutter observed when tapping the button after this change