### PR TITLE
Restore a working way to skip macOS App Sandbox entitlement checks (darwin-only)

### DIFF
--- a/packages/file_picker_darwin/CHANGELOG.md
+++ b/packages/file_picker_darwin/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed bundle-like directories (e.g. `.app`, `.fcpbundle`) not being selectable as files on macOS file pickers, a regression since 8.2.0. `NSOpenPanel.treatsFilePackagesAsDirectories` is now explicitly set to `false` so these are presented as selectable files, matching Finder and other native apps.
 - Fixed `saveFile` on macOS never enforcing an extension on the destination file when the user cleared it from the suggested name. `allowedExtensions` is not forwarded to `saveFile` yet, so the dialog now falls back to the extension of the suggested file name.
 - Fixed `saveFile` returning a scheme-less, percent-encoded `Uri` on macOS instead of a proper `file://` Uri, unlike Windows and Linux.
+- Added `FilePickerDarwin.skipEntitlementsChecks()`, letting non-sandboxed macOS apps opt out of the App Sandbox entitlement checks performed before showing a dialog. This was previously only reachable through a deprecated, no-op method on `FilePicker` in the root package.
 
 ## 1.0.1
 

--- a/packages/file_picker_darwin/lib/src/file_picker_darwin.dart
+++ b/packages/file_picker_darwin/lib/src/file_picker_darwin.dart
@@ -173,6 +173,29 @@ class FilePickerDarwin extends FilePickerPlatform {
     await methodChannel.invokeMethod<void>('clear');
   }
 
+  /// Skips the macOS App Sandbox entitlement checks performed before showing a dialog.
+  ///
+  /// Only relevant for non-sandboxed macOS apps, which do not declare the
+  /// `com.apple.security.files.user-selected.read-only`/`read-write` entitlements
+  /// and would otherwise be incorrectly blocked by those checks. Call this before
+  /// any other file picking method.
+  ///
+  /// This method does nothing on iOS.
+  ///
+  /// Note: skipping entitlement checks may lead to unexpected behavior if the
+  /// app is actually sandboxed. Use with caution.
+  ///
+  /// ```dart
+  /// if (FilePickerPlatform.instance case final FilePickerDarwin instance) {
+  ///   await instance.skipEntitlementsChecks();
+  /// }
+  /// ```
+  Future<void> skipEntitlementsChecks() async {
+    // Only macOS performs App Sandbox entitlement checks, this is a no-op on iOS.
+    if (!Platform.isMacOS) return;
+    await methodChannel.invokeMethod<void>('skipEntitlementsChecks');
+  }
+
   @override
   Future<Uri?> saveFile({
     required String fileName,


### PR DESCRIPTION
## Summary

Split into a darwin-only, non-breaking PR per review feedback. This PR no longer touches `file_picker` or removes anything.

- The native `skipEntitlementsChecks` mechanism in `MacOSFilePickerHandler` always existed and worked, but the only public Dart entry point, `FilePicker.skipEntitlementsChecks()`, was turned into a deprecated no-op during the v12 federation rewrite. The deprecation message assumed entitlement checks would be "handled automatically", but `checkEntitlement` has no way to detect whether the host app is actually sandboxed, so a non-sandboxed app has no way to opt out and gets incorrectly blocked with `ENTITLEMENT_NOT_FOUND`/`ENTITLEMENT_REQUIRED_WRITE`.
- Adds `FilePickerDarwin.skipEntitlementsChecks()` as a real, working entry point, for apps that specifically depend on `file_picker_darwin`:
  ```dart
  if (FilePickerPlatform.instance case final FilePickerDarwin instance) {
    await instance.skipEntitlementsChecks();
  }
  ```
- The deprecated `FilePicker.skipEntitlementsChecks()` no-op on the root package is left untouched here. A follow-up PR against `file_picker` will make it delegate to this once `file_picker_darwin`'s version with this method is out, instead of removing it, so no breaking change is needed at all.

Fixes #2143

## Test plan
- [x] `dart analyze` passes on `file_picker_darwin`
- [x] `flutter test` passes on `file_picker_darwin`
- [ ] Manual verification on a non-sandboxed macOS app: confirm calling `FilePickerDarwin.skipEntitlementsChecks()` before `pickFiles()` avoids the entitlement error
