### PR TITLE
chore(android): drop the stale buildscript classpath

### DIFF
--- a/packages/file_picker_android/CHANGELOG.md
+++ b/packages/file_picker_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+- Removed the stale `buildscript` classpath from the Android module, which pinned AGP 8.5.2 and Kotlin Gradle Plugin 1.8.22 in a module that supports AGP 9 and Kotlin 2.3. [#2154](https://github.com/miguelpruivo/flutter_file_picker/pull/2154)
+
 ## 1.0.1
 
 - Improved package description, added example, and added missing API documentation.

--- a/packages/file_picker_android/android/build.gradle.kts
+++ b/packages/file_picker_android/android/build.gradle.kts
@@ -6,18 +6,6 @@ import org.gradle.kotlin.dsl.withGroovyBuilder
 group = "com.mr.flutter.plugin.filepicker"
 version = "1.0-SNAPSHOT"
 
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath("com.android.tools.build:gradle:8.5.2")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22")
-    }
-}
-
 rootProject.allprojects {
     repositories {
         google()

--- a/packages/file_picker_android/pubspec.yaml
+++ b/packages/file_picker_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: android_file_picker
 description: Android implementation of the file_picker plugin, supporting file picking, saving, and Storage Access Framework (SAF) URI grants.
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_android
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_android
 topics:


### PR DESCRIPTION
Surfaced while triaging #2152. It is not a fix for that issue, but it is real debt that the issue made visible.

## What

`packages/file_picker_android/android/build.gradle.kts` is the **only** package in the repo that declares a buildscript classpath:

```kotlin
buildscript {
    repositories { google(); mavenCentral() }
    dependencies {
        classpath("com.android.tools.build:gradle:8.5.2")
        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22")
    }
}
```

It pins AGP 8.5.2 and Kotlin Gradle Plugin 1.8.22 in a module whose own logic branches on `agpVersion >= 9` and which CI builds against Kotlin 2.3.21. It arrived with `7abb09f feat(android): extract file_picker_android package` and is leftover from an older plugin template. Current Flutter plugin templates do not include it.

## Why it is safe

Gradle's buildscript classpath is hierarchical, so a subproject script inherits the root project's. That is where `com.android.library`, `org.jetbrains.kotlin.android` and the `com.android.build.gradle.LibraryExtension` import actually resolve from. The proof is that CI already builds this module against AGP 9.2.1 and Kotlin 2.3.21 with the block present, which could not happen if the local 1.8.22 classpath were winning.

So this removes a contradiction rather than changing behaviour.

## Verification

I have no JDK on this machine, so this is deliberately left to the `agp-8.x` and `agp-9.x` lanes. They build the example app, which builds this module, and the 9.x lane also does a release build that exercises R8. That is exactly the coverage those lanes exist for.

Bumped to 1.0.2 with a CHANGELOG entry. 1.0.1 is already on pub.dev, so the entry opens a new section rather than editing a published one. Patch bump, so the `^1.0.0` constraints in `file_picker` and the example keep resolving unchanged.

## Not in scope

The `rootProject.allprojects { repositories { ... } }` block just below is the same kind of legacy, and cross-project configuration like that is discouraged in modern Gradle. I left it alone because removing it could genuinely break dependency resolution for consumers whose root build does not declare those repositories. Worth a separate look.

