### PR TITLE
fix(ios): extract still image from Live Photo .pvt package instead of crashing

### DIFF
--- a/packages/file_picker/CHANGELOG.md
+++ b/packages/file_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.0.1
+### iOS
+- Fixed a crash (`FileSystemException`/`OSError: Is a directory`) when picking a Live Photo from the gallery. Live Photos are saved by iOS as `.pvt` packages (directories); the still image contained in the package is now extracted instead of returning the package itself.
+
 ## 12.0.0
 
 ### Breaking Changes

--- a/packages/file_picker/pubspec.yaml
+++ b/packages/file_picker/pubspec.yaml
@@ -9,7 +9,7 @@ topics:
   - storage
   - desktop
   - web
-version: 12.0.0
+version: 12.0.1
 
 resolution: workspace
 

--- a/packages/file_picker_darwin/CHANGELOG.md
+++ b/packages/file_picker_darwin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+- Fixed a crash (`FileSystemException`/`OSError: Is a directory`) when picking a Live Photo from the iOS gallery. Live Photos are saved by iOS as `.pvt` packages (directories), which `loadFileRepresentation(forTypeIdentifier: UTType.item...)` returned as-is; the still image contained in the package is now extracted instead.
+
 ## 1.0.1
 
 - Fixed `pickFileAndDirectoryPaths` never returning directories on iOS and macOS. It now calls the native combined file and directory picker instead of silently falling back to file only selection.

--- a/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/IOSFilePickerHandler.swift
+++ b/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/IOSFilePickerHandler.swift
@@ -360,10 +360,36 @@ final class IOSFilePickerHandler: NSObject,
                 try FileManager.default.removeItem(at: destinationURL)
             }
             try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
-            return destinationURL
+            return resolveActualFile(at: destinationURL)
         } catch {
             return nil
         }
+    }
+
+    /// Some `PHPickerResult` items (notably Live Photos, which iOS saves as
+    /// `.pvt` packages) resolve to a *directory* rather than a regular file
+    /// when loaded via `loadFileRepresentation(forTypeIdentifier: UTType.item...)`.
+    /// Reading such a path as a file later fails with "Is a directory" (errno 21).
+    /// When that happens, return the still image contained in the package
+    /// instead of the package itself.
+    private func resolveActualFile(at url: URL) -> URL? {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+            return nil
+        }
+        guard isDirectory.boolValue else {
+            return url
+        }
+
+        let imageExtensions = ["jpg", "jpeg", "heic", "heif", "png"]
+        guard let contents = try? FileManager.default.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: nil
+        ) else {
+            return nil
+        }
+
+        return contents.first { imageExtensions.contains($0.pathExtension.lowercased()) }
     }
 
     private func makeFileInfo(from fileURL: URL) -> [String: Any]? {

--- a/packages/file_picker_darwin/pubspec.yaml
+++ b/packages/file_picker_darwin/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_picker_darwin
 description: Darwin (iOS and macOS) implementation of the file_picker plugin, supporting native file picking, saving, and directory selection.
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_darwin
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_darwin
 topics:


### PR DESCRIPTION
Fixes #2157

### Problem

Picking a Live Photo from the gallery on iOS crashes callers who read the picked file as bytes, with:

```
FileSystemException: Cannot open file, path = '.../tmp/IMG_9509.pvt' (OS Error: Is a directory, errno = 21)
```

iOS saves Live Photos picked via `PHPickerViewController` as `.pvt` packages, which are **directories** (containing the still image, the paired `.mov`, and metadata), not regular files. `copyToTemporaryDirectory` in `IOSFilePickerHandler.swift` copies whatever `loadFileRepresentation` resolves to verbatim and hands that path back to Dart as the picked file — for a Live Photo, that's the whole package directory.

### Fix

Added `resolveActualFile(at:)`, called from `copyToTemporaryDirectory` right after the copy: if the copied path is a directory, it looks inside for the first file with an image extension (`jpg`/`jpeg`/`heic`/`heif`/`png`) and returns that instead of the package path. Regular (non-package) files are returned unchanged, so this only affects the Live Photo case.

### Why this approach

- Minimal, localized to the one function that already owns "resolve the picked item into a file we hand back to Dart" — no changes to the Dart-facing API or other platforms.
- Doesn't depend on a specific Live Photo UTType (which can vary across iOS versions) — it just handles "the picker gave us a directory" generically, which also protects against any other package-like result iOS might return.

### Testing

Verified the logic against the reported crash conditions (a `.pvt` package containing a JPEG + MOV). This package doesn't have an existing Swift/native test harness (per CONTRIBUTING.md, "Java/Objective-C code is currently not tested"), so I didn't add one — happy to add a target if you'd like one for this.

### Changes

- `packages/file_picker_darwin`: fix + patch bump to 1.0.2 + changelog entry.
- `packages/file_picker`: patch bump to 12.0.1 + changelog entry (per CONTRIBUTING.md guidance to bump the version and changelog for a bugfix PR).