### PR TITLE
fix(darwin): enforce default extension and fix Uri scheme in macOS saveFile

### DIFF
--- a/packages/file_picker_darwin/CHANGELOG.md
+++ b/packages/file_picker_darwin/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Fixed `getDirectoryPath`, `pickFiles`, `pickFileAndDirectoryPaths`, and `saveFile` on macOS defaulting to the sandbox container's `Data` folder instead of the user's real home directory when no `initialDirectory` is provided and the app has App Sandbox enabled.
 - Fixed the Save dialog on macOS auto-selecting the file extension along with the rest of the file name, making it easy to accidentally delete the extension when renaming. The extension is now hidden by default via `NSSavePanel.isExtensionHidden`.
 - Fixed bundle-like directories (e.g. `.app`, `.fcpbundle`) not being selectable as files on macOS file pickers, a regression since 8.2.0. `NSOpenPanel.treatsFilePackagesAsDirectories` is now explicitly set to `false` so these are presented as selectable files, matching Finder and other native apps.
+- Fixed `saveFile` on macOS never enforcing an extension on the destination file when the user cleared it from the suggested name. `allowedExtensions` is not forwarded to `saveFile` yet, so the dialog now falls back to the extension of the suggested file name.
+- Fixed `saveFile` returning a scheme-less, percent-encoded `Uri` on macOS instead of a proper `file://` Uri, unlike Windows and Linux.
 
 ## 1.0.1
 

--- a/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/MacOSFilePickerHandler.swift
+++ b/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/MacOSFilePickerHandler.swift
@@ -257,6 +257,9 @@ final class MacOSFilePickerHandler: NSObject, FlutterStreamHandler {
 
         let extensions = args["allowedExtensions"] as? [String] ?? []
         applyExtensions(dialog, extensions, method: call.method)
+        if extensions.isEmpty {
+            applyDefaultExtension(dialog, fileName: args["fileName"] as? String ?? "")
+        }
 
         guard let appWindow = getFlutterWindow() else {
             result(nil)
@@ -374,6 +377,24 @@ final class MacOSFilePickerHandler: NSObject, FlutterStreamHandler {
             if !fileTypes.isEmpty {
                 dialog.allowedFileTypes = fileTypes
             }
+        }
+    }
+
+    /// `saveFile()` never forwards `allowedExtensions` down to the native save
+    /// dialog, so `applyExtensions` has nothing to enforce and `NSSavePanel`
+    /// won't append or require any extension. Fall back to the extension of
+    /// the suggested file name, so a name like "Report.txt" still enforces
+    /// ".txt" even though no explicit extension list reached this call.
+    private func applyDefaultExtension(_ dialog: NSSavePanel, fileName: String) {
+        let ext = (fileName as NSString).pathExtension
+        guard !ext.isEmpty else { return }
+
+        if #available(macOS 11.0, *) {
+            if let type = UTType(filenameExtension: ext) {
+                dialog.allowedContentTypes = [type]
+            }
+        } else {
+            dialog.allowedFileTypes = [ext]
         }
     }
 

--- a/packages/file_picker_darwin/lib/src/file_picker_darwin.dart
+++ b/packages/file_picker_darwin/lib/src/file_picker_darwin.dart
@@ -220,7 +220,7 @@ class FilePickerDarwin extends FilePickerPlatform {
       }
 
       if (savedPath == null) return null;
-      return Uri.tryParse(savedPath) ?? Uri.file(savedPath);
+      return Uri.file(savedPath);
     } catch (e) {
       rethrow;
     } finally {


### PR DESCRIPTION
## Problem

Two related bugs in `saveFile()` on macOS.

### #2159: extension not enforced

`allowedExtensions` is not forwarded from the `saveFile()` API down to the native save dialog at all (`file_picker`, `file_picker_platform_interface`, and `file_picker_darwin` all drop it before it reaches `MacOSFilePickerHandler.swift`). Because of that, `applyExtensions` always falls into its empty branch for the `"save"` method, so `NSSavePanel.allowedContentTypes` is never set. If the user clears the extension from the suggested file name, the file gets saved with none.

This is the macOS counterpart of #2139, which was fixed for Windows in #2140.

### #2160: scheme-less Uri

`FilePickerDarwin.saveFile()` returned `Uri.tryParse(savedPath) ?? Uri.file(savedPath)`. `savedPath` is always a native POSIX path (`url.path` from `NSSavePanel`/`UIDocumentPickerViewController`), never a URI string, so `Uri.tryParse` always succeeds and returns a relative, scheme-less Uri, and the `Uri.file` fallback never runs. Any path containing a space or non-ASCII character comes out percent-encoded and `Uri.scheme` doesn't match any of the documented values, unlike Windows and Linux which already return `Uri.file(...)`.

## Fix

- `handleSaveFile` now falls back to the extension of the suggested `fileName` when no `allowedExtensions` reached it, on both the `UTType` (macOS 11+) and legacy (`allowedFileTypes`) paths, mirroring the `lpstrDefExt` approach already used for Windows in #2140. Full plumbing of `allowedExtensions` through the public API remains a separate, larger change.
- `FilePickerDarwin.saveFile()` now always returns `Uri.file(savedPath)`, matching Windows and Linux.

## Test plan
- [x] `swift build` succeeds for `file_picker_darwin`
- [x] `dart analyze` passes on the modified file
- [ ] Manual verification with the example app on macOS: `saveFile(fileName: 'Report.txt', ...)`, clear the extension in the panel, save, and confirm it is written back as `.txt`
- [ ] Manual verification that the returned `Uri` has `scheme == 'file'` and `toFilePath()` matches the saved path for a directory containing a space
