### PR TITLE
feat(platform_interface): add PlatformFile.extension

### DIFF
--- a/packages/file_picker/CHANGELOG.md
+++ b/packages/file_picker/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 12.0.1
+## 12.1.0
+
+### General
+- Added `PlatformFile.extension`, restoring the pre-12.0 convenience getter that was dropped during the federated rewrite. Returns the file extension of `name` without the leading dot, or `null` if there is none.
+
 ### iOS
 - Fixed a crash (`FileSystemException`/`OSError: Is a directory`) when picking a Live Photo from the gallery. Live Photos are saved by iOS as `.pvt` packages (directories); the still image contained in the package is now extracted instead of returning the package itself.
 

--- a/packages/file_picker/pubspec.yaml
+++ b/packages/file_picker/pubspec.yaml
@@ -9,7 +9,7 @@ topics:
   - storage
   - desktop
   - web
-version: 12.0.1
+version: 12.1.0
 
 resolution: workspace
 
@@ -21,7 +21,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  file_picker_platform_interface: ^3.0.0
+  file_picker_platform_interface: ^3.1.0
   android_file_picker: ^1.0.0
   file_picker_darwin: ^1.0.0
   file_picker_linux: ^1.0.0

--- a/packages/file_picker_platform_interface/CHANGELOG.md
+++ b/packages/file_picker_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0
+
+- Added `PlatformFile.extension`, restoring the pre-12.0 convenience getter that was dropped during the federated rewrite. Returns the file extension of `name` without the leading dot, or `null` if there is none.
+
 ## 3.0.1
 
 - Improved package description, added example, and added missing API documentation.

--- a/packages/file_picker_platform_interface/lib/src/platform_file.dart
+++ b/packages/file_picker_platform_interface/lib/src/platform_file.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:cross_file/cross_file.dart';
+import 'package:path/path.dart' as p;
 
 /// The abstract representation of a picked file on the current platform.
 ///
@@ -9,6 +10,18 @@ import 'package:cross_file/cross_file.dart';
 abstract base class PlatformFile {
   /// The name of the underlying file, including the extension.
   String get name;
+
+  /// The file extension of [name], without the leading dot, or `null` if
+  /// [name] has none.
+  ///
+  /// Delegates to `package:path`'s `extension()` for the parsing (so a
+  /// dotfile like `.gitignore` does not count as an extension), stripping
+  /// the leading dot it includes to match [name]'s own convention and the
+  /// rest of this package's API (`allowedExtensions` is also dot-less).
+  String? get extension {
+    final ext = p.extension(name);
+    return ext.isEmpty ? null : ext.substring(1);
+  }
 
   /// An [Uri] to the underlying file.
   ///

--- a/packages/file_picker_platform_interface/pubspec.yaml
+++ b/packages/file_picker_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_picker_platform_interface
 description: A common platform interface for the file_picker plugin, defining the shared API surface and data contracts across platforms.
-version: 3.0.1
+version: 3.1.0
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_platform_interface
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_platform_interface
 topics:

--- a/packages/file_picker_platform_interface/test/platform_file_test.dart
+++ b/packages/file_picker_platform_interface/test/platform_file_test.dart
@@ -1,0 +1,51 @@
+import 'dart:typed_data';
+
+import 'package:cross_file/cross_file.dart';
+import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+base class _TestPlatformFile extends PlatformFile {
+  _TestPlatformFile(this.name);
+
+  @override
+  final String name;
+
+  @override
+  Uri get uri => Uri.file(name);
+
+  @override
+  XFile get xFile => XFile(name);
+
+  @override
+  Future<int> length() async => 0;
+
+  @override
+  Future<Uint8List> readAsBytes() async => Uint8List(0);
+
+  @override
+  Stream<Uint8List> readAsByteStream() => const Stream.empty();
+}
+
+void main() {
+  group('PlatformFile.extension', () {
+    test('returns the extension without the leading dot', () {
+      expect(_TestPlatformFile('report.pdf').extension, 'pdf');
+    });
+
+    test('returns the last extension for multi-dot names', () {
+      expect(_TestPlatformFile('archive.tar.gz').extension, 'gz');
+    });
+
+    test('returns null when there is no extension', () {
+      expect(_TestPlatformFile('README').extension, isNull);
+    });
+
+    test('returns null for a dotfile with no other dot', () {
+      expect(_TestPlatformFile('.gitignore').extension, isNull);
+    });
+
+    test('returns the extension for a dotfile with a real extension', () {
+      expect(_TestPlatformFile('.env.local').extension, 'local');
+    });
+  });
+}


### PR DESCRIPTION
## Why

`PlatformFile.extension` existed for years before the v12 federated rewrite and was dropped without a replacement. #2161 and its comments (from milindgoel15) flagged this, asking for either the getter back or at least the migration path documented.

## What

- Added `PlatformFile.extension` back to `file_picker_platform_interface`, as a concrete getter on the base class (no platform-specific implementation needs to change).
- Delegates to `package:path`'s `extension()` for the actual parsing (already a dependency of this package), so a dotfile like `.gitignore` correctly returns `null` instead of treating the whole name as an extension, which was a real bug in the pre-12.0 getter (`name.split('.').last` returned `'README'` for a file with no extension at all).
- Strips the leading dot `package:path` includes, to match `name`'s own convention and `allowedExtensions` elsewhere in this API, which are both dot-less.
- Works unmodified on every platform, including web: it only reads `name`, never `path`/`uri`, so it is unaffected by web's `blob:`/`data:` URIs.

## Changes

- `file_picker_platform_interface`: 3.0.1 → 3.1.0 (minor, pure addition).
- `file_picker`: 12.0.1 → 12.1.0, folded together with the already-merged #2158 entry since 12.0.1 was never published. Dependency constraint bumped to `file_picker_platform_interface: ^3.1.0` so the getter is guaranteed available once this is picked up.

## Test plan
- [x] `dart analyze` passes on `file_picker_platform_interface` and `file_picker`
- [x] `flutter test` passes on both packages
- [x] New unit tests cover: normal extension, multi-dot (`archive.tar.gz` → `gz`), no extension (`README` → `null`), dotfile with no other dot (`.gitignore` → `null`), dotfile with a real extension (`.env.local` → `local`)
