### PR TITLE
docs: add root README and LICENSE

### DIFF
--- a/.github/assets/readme_banner.svg
+++ b/.github/assets/readme_banner.svg
@@ -1,0 +1,71 @@
+<svg width="1200" height="320" viewBox="0 0 1200 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="File Picker">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4338CA"/>
+      <stop offset="55%" stop-color="#2563EB"/>
+      <stop offset="100%" stop-color="#06B6D4"/>
+    </linearGradient>
+    <linearGradient id="folderBack" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.30"/>
+      <stop offset="100%" stop-color="#FFFFFF" stop-opacity="0.18"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="0" y="0" width="1200" height="320" rx="28" fill="url(#bg)"/>
+
+  <circle cx="1080" cy="40" r="90" fill="#FFFFFF" opacity="0.06"/>
+  <circle cx="1150" cy="260" r="130" fill="#FFFFFF" opacity="0.05"/>
+  <circle cx="150" cy="30" r="10" fill="#FFFFFF" opacity="0.35"/>
+  <circle cx="330" cy="55" r="6" fill="#FFFFFF" opacity="0.3"/>
+  <circle cx="95" cy="230" r="7" fill="#FFFFFF" opacity="0.3"/>
+
+  <!-- floating file cards -->
+  <g transform="translate(150,150) rotate(-14)">
+    <rect x="-46" y="-60" width="92" height="118" rx="14" fill="#FDBA74"/>
+    <rect x="-30" y="-38" width="60" height="8" rx="4" fill="#FFFFFF" opacity="0.85"/>
+    <rect x="-30" y="-20" width="60" height="8" rx="4" fill="#FFFFFF" opacity="0.65"/>
+    <rect x="-30" y="-2" width="38" height="8" rx="4" fill="#FFFFFF" opacity="0.65"/>
+  </g>
+
+  <g transform="translate(238,128) rotate(9)">
+    <rect x="-46" y="-62" width="92" height="122" rx="14" fill="#5EEAD4"/>
+    <circle cx="-14" cy="-30" r="12" fill="#FFFFFF" opacity="0.9"/>
+    <path d="M -32 8 L -8 -16 L 10 2 L 22 -10 L 34 2 L 34 8 Z" fill="#FFFFFF" opacity="0.85"/>
+  </g>
+
+  <g transform="translate(196,196) rotate(-3)">
+    <rect x="-50" y="-64" width="100" height="128" rx="16" fill="#FFFFFF"/>
+    <rect x="-32" y="-40" width="64" height="9" rx="4.5" fill="#93C5FD"/>
+    <rect x="-32" y="-20" width="64" height="9" rx="4.5" fill="#BFDBFE"/>
+    <rect x="-32" y="0" width="40" height="9" rx="4.5" fill="#BFDBFE"/>
+    <path d="M -14 32 L -2 44 L 22 20" fill="none" stroke="#34D399" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+
+  <!-- open folder in front -->
+  <path d="M 60 250 L 340 250 L 322 168 Q 318 152 300 152 L 210 152 L 196 130 Q 190 120 176 120 L 96 120 Q 82 120 78 134 Z" fill="url(#folderBack)" stroke="#FFFFFF" stroke-opacity="0.5" stroke-width="2"/>
+
+  <!-- title -->
+  <text x="440" y="150" font-family="Helvetica, Arial, sans-serif" font-size="72" font-weight="700" fill="#FFFFFF">File Picker</text>
+  <text x="442" y="196" font-family="Helvetica, Arial, sans-serif" font-size="26" font-weight="400" fill="#E0E7FF">Pick, save, and browse files. Every platform, one API.</text>
+
+  <!-- platform pills -->
+  <g font-family="Helvetica, Arial, sans-serif" font-size="18" font-weight="600" fill="#1E293B">
+    <rect x="442" y="228" width="96" height="38" rx="19" fill="#FFFFFF" opacity="0.92"/>
+    <text x="490" y="253" text-anchor="middle">Android</text>
+
+    <rect x="550" y="228" width="70" height="38" rx="19" fill="#FFFFFF" opacity="0.92"/>
+    <text x="585" y="253" text-anchor="middle">iOS</text>
+
+    <rect x="632" y="228" width="90" height="38" rx="19" fill="#FFFFFF" opacity="0.92"/>
+    <text x="677" y="253" text-anchor="middle">macOS</text>
+
+    <rect x="734" y="228" width="94" height="38" rx="19" fill="#FFFFFF" opacity="0.92"/>
+    <text x="781" y="253" text-anchor="middle">Windows</text>
+
+    <rect x="840" y="228" width="82" height="38" rx="19" fill="#FFFFFF" opacity="0.92"/>
+    <text x="881" y="253" text-anchor="middle">Linux</text>
+
+    <rect x="934" y="228" width="76" height="38" rx="19" fill="#FFFFFF" opacity="0.92"/>
+    <text x="972" y="253" text-anchor="middle">Web</text>
+  </g>
+</svg>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Miguel Ruivo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![file_picker](https://user-images.githubusercontent.com/27860743/64064695-b88dab00-cbfc-11e9-814f-30921b66035f.png)
+![File Picker](.github/assets/readme_banner.svg)
 
 <p align="center">
   <a href="https://pub.dev/packages/file_picker">

--- a/README.md
+++ b/README.md
@@ -1,0 +1,84 @@
+![file_picker](https://user-images.githubusercontent.com/27860743/64064695-b88dab00-cbfc-11e9-814f-30921b66035f.png)
+
+<p align="center">
+  <a href="https://pub.dev/packages/file_picker">
+    <img alt="pub package" src="https://img.shields.io/pub/v/file_picker.svg">
+  </a>
+  <a href="https://github.com/miguelpruivo/flutter_file_picker/actions/workflows/main.yml">
+    <img alt="CI pipeline status" src="https://github.com/miguelpruivo/flutter_file_picker/actions/workflows/main.yml/badge.svg">
+  </a>
+  <a href="https://github.com/miguelpruivo/flutter_file_picker/issues">
+    <img alt="GitHub issues" src="https://img.shields.io/github/issues/miguelpruivo/flutter_file_picker">
+  </a>
+  <a href="https://github.com/miguelpruivo/flutter_file_picker/blob/master/LICENSE">
+    <img alt="License" src="https://img.shields.io/github/license/miguelpruivo/flutter_file_picker">
+  </a>
+  <a href="https://github.com/Solido/awesome-flutter">
+    <img alt="Awesome Flutter" src="https://img.shields.io/badge/Awesome-Flutter-blue.svg?longCache=true&style=flat-square">
+  </a>
+</p>
+
+# File Picker
+
+A Flutter plugin that lets you use the native file explorer to pick single or multiple files, with extension filtering, directory selection, and save-file dialogs, across Android, iOS, Linux, macOS, Windows, and Web.
+
+This repository is a [Melos](https://melos.invertase.dev/) workspace hosting `file_picker` as a **federated plugin**: a single cross-platform API package on top of one implementation package per platform, all versioned and published independently.
+
+## Packages
+
+| Package | Pub | Description |
+|---|---|---|
+| [`file_picker`](packages/file_picker) | [![pub](https://img.shields.io/pub/v/file_picker.svg)](https://pub.dev/packages/file_picker) | The main package. Add this to your app, it pulls in the right platform implementation automatically. |
+| [`file_picker_platform_interface`](packages/file_picker_platform_interface) | [![pub](https://img.shields.io/pub/v/file_picker_platform_interface.svg)](https://pub.dev/packages/file_picker_platform_interface) | The shared interface and data contracts (`PlatformFile`, `FileType`, platform option classes) every implementation builds on. |
+| [`file_picker_darwin`](packages/file_picker_darwin) | [![pub](https://img.shields.io/pub/v/file_picker_darwin.svg)](https://pub.dev/packages/file_picker_darwin) | iOS and macOS implementation. |
+| [`android_file_picker`](packages/file_picker_android) | [![pub](https://img.shields.io/pub/v/android_file_picker.svg)](https://pub.dev/packages/android_file_picker) | Android implementation, including Storage Access Framework (SAF) support. |
+| [`file_picker_linux`](packages/file_picker_linux) | [![pub](https://img.shields.io/pub/v/file_picker_linux.svg)](https://pub.dev/packages/file_picker_linux) | Linux implementation, using GTK3 and XDG Desktop Portals. |
+| [`windows_file_picker`](packages/file_picker_windows) | [![pub](https://img.shields.io/pub/v/windows_file_picker.svg)](https://pub.dev/packages/windows_file_picker) | Windows implementation, using the Win32 COM APIs. |
+| [`file_picker_web`](packages/file_picker_web) | [![pub](https://img.shields.io/pub/v/file_picker_web.svg)](https://pub.dev/packages/file_picker_web) | Web implementation, including Wasm compilation support. |
+
+Almost all apps should only ever depend on `file_picker` directly. The platform packages are pulled in transitively and registered automatically by Flutter's plugin system; you only reach for one of them directly if you need a platform-specific API that isn't exposed on the shared facade (for example `FilePickerDarwin.skipEntitlementsChecks()` on macOS).
+
+## Quick start
+
+```yaml
+dependencies:
+  file_picker: ^12.0.0
+```
+
+```dart
+import 'package:file_picker/file_picker.dart';
+
+final file = await FilePicker.pickFile();
+
+if (file != null) {
+  print(file.name);
+  print(await file.length());
+}
+```
+
+See [`packages/file_picker/README.md`](packages/file_picker/README.md) for the full feature list, platform compatibility chart, and more usage examples (multiple files, extension filters, directory picking, save-file dialogs).
+
+## Documentation
+
+- [File Picker Wiki](https://github.com/miguelpruivo/flutter_file_picker/wiki) — installation, setup, and usage guides.
+- [API reference on pub.dev](https://pub.dev/documentation/file_picker/latest/file_picker/FilePicker-class.html).
+- [`packages/file_picker/CHANGELOG.md`](packages/file_picker/CHANGELOG.md) and each platform package's own `CHANGELOG.md` for release notes.
+
+## Contributing
+
+Contributions are welcome. Please read [`CONTRIBUTING.md`](CONTRIBUTING.md) before opening a pull request, it covers testing requirements, versioning, and changelog conventions for this workspace.
+
+To work on this repository locally:
+
+```sh
+dart pub global activate melos
+melos bootstrap
+melos run analyze   # flutter analyze across every package
+melos run test       # flutter test across every package
+```
+
+Each package keeps its own `pubspec.yaml` and `CHANGELOG.md` and is released independently, only the package(s) you actually changed need a version bump.
+
+## License
+
+MIT, see [`LICENSE`](LICENSE). Every package in this repository is released under the same license.


### PR DESCRIPTION
## Why

The repository root had no `README.md` or `LICENSE`, only `CONTRIBUTING.md`. Anyone landing on the repo on GitHub saw an empty root with no explanation of the federated architecture or which package to depend on.

## What

- Added a root `README.md`: badges, a short intro, a table of all 7 packages linking each to its real pub.dev package name (`file_picker_android` publishes as `android_file_picker`, `file_picker_windows` as `windows_file_picker`), a minimal quick-start snippet, links to the Wiki/API reference/CHANGELOGs, and a Contributing section with the Melos commands for local development.
- Added a root `LICENSE`, copied from `packages/file_picker/LICENSE` (identical MIT text already published with every package), so GitHub picks it up in the repo sidebar instead of only inside each package folder.

Deliberately kept this lean and pointed at `packages/file_picker/README.md` for the full feature list and usage examples, rather than duplicating that content here.

## Test plan
- [x] Docs-only change, no code affected
