### PR TITLE
fix(file_picker): make skipEntitlementsChecks delegate to FilePickerDarwin

### DIFF
--- a/packages/file_picker/CHANGELOG.md
+++ b/packages/file_picker/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### iOS
 - Fixed a crash (`FileSystemException`/`OSError: Is a directory`) when picking a Live Photo from the gallery. Live Photos are saved by iOS as `.pvt` packages (directories); the still image contained in the package is now extracted instead of returning the package itself.
 
+### macOS
+- Fixed `FilePicker.skipEntitlementsChecks()` being a permanent no-op. It now delegates to `FilePickerDarwin.skipEntitlementsChecks()` when running on macOS, so non-sandboxed apps can actually skip the App Sandbox entitlement checks again.
+
 ## 12.0.0
 
 ### Breaking Changes

--- a/packages/file_picker/lib/src/file_picker.dart
+++ b/packages/file_picker/lib/src/file_picker.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:android_file_picker/android_file_picker.dart';
+import 'package:file_picker_darwin/file_picker_darwin.dart';
 import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
 import 'package:flutter/foundation.dart';
 
@@ -244,9 +245,20 @@ abstract final class FilePicker {
     );
   }
 
-  /// Deprecated entitlement check helper for legacy compatibility.
-  @Deprecated(
-    'Entitlements checks are handled automatically by file_picker_darwin.',
-  )
-  static Future<void> skipEntitlementsChecks() async {}
+  /// Skips the macOS App Sandbox entitlement checks performed before showing a dialog.
+  ///
+  /// Only relevant for non-sandboxed macOS apps, which do not declare the
+  /// `com.apple.security.files.user-selected.read-only`/`read-write` entitlements
+  /// and would otherwise be incorrectly blocked by those checks. Call this before
+  /// any other file picking method.
+  ///
+  /// This method does nothing on iOS, and on every platform other than macOS.
+  ///
+  /// Note: skipping entitlement checks may lead to unexpected behavior if the
+  /// app is actually sandboxed. Use with caution.
+  static Future<void> skipEntitlementsChecks() async {
+    if (FilePickerPlatform.instance case final FilePickerDarwin instance) {
+      await instance.skipEntitlementsChecks();
+    }
+  }
 }

--- a/packages/file_picker/lib/src/file_picker.dart
+++ b/packages/file_picker/lib/src/file_picker.dart
@@ -252,7 +252,7 @@ abstract final class FilePicker {
   /// and would otherwise be incorrectly blocked by those checks. Call this before
   /// any other file picking method.
   ///
-  /// This method does nothing on iOS, and on every platform other than macOS.
+  /// This method does nothing on platforms other than macOS.
   ///
   /// Note: skipping entitlement checks may lead to unexpected behavior if the
   /// app is actually sandboxed. Use with caution.


### PR DESCRIPTION
## Why

Follow-up to #2150, split out per review feedback to avoid a breaking change on `file_picker`.

`FilePicker.skipEntitlementsChecks()` was turned into a permanent no-op during the v12 federation, with `FilePickerDarwin.skipEntitlementsChecks()` (added in #2150) as the only real, working entry point, reachable only by apps that depend on `file_picker_darwin` directly.

## What

Instead of removing the deprecated no-op (which would be a breaking change), it now delegates to the real implementation:

```dart
static Future<void> skipEntitlementsChecks() async {
  if (FilePickerPlatform.instance case final FilePickerDarwin instance) {
    await instance.skipEntitlementsChecks();
  }
}
```

No breaking change, no major/minor bump needed beyond what #2150 already carries, this rides along as a bug fix bullet in the same unpublished `12.1.0`.

Verified that importing `file_picker_darwin` directly from `file_picker.dart` does not break Web/Wasm builds (`flutter build web` and `flutter build web --wasm` both succeed), since `file_picker_darwin`'s Dart-level `dart:io` usage is tree-shaken away when never reached on that platform.

## Depends on

Based on #2150's branch since it needs `FilePickerDarwin.skipEntitlementsChecks()` to exist. Should not be merged before #2150.

## Test plan
- [x] `dart analyze` passes on `file_picker`
- [x] `flutter test` passes on `file_picker`
- [x] `flutter build web` and `flutter build web --wasm` succeed with the example app
