### PR TITLE
fix(ci): set up OIDC for pub.dev publishing in the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,18 @@ jobs:
 
       - uses: bluefireteam/melos-action@v3
 
+      # bluefireteam/melos-action only runs its own dart-lang/setup-dart step
+      # (the one that wires up OIDC-based pub.dev publishing) when its own
+      # `publish: true` input is set, which is meant for its single-package,
+      # tag-triggered publish flow, not our multi-package workflow_dispatch
+      # flow below. Without this, dart pub publish falls back to interactive
+      # browser OAuth, which can never complete on a CI runner.
+      - name: Set up Dart SDK for OIDC-based pub.dev publishing
+        if: ${{ !inputs.dry_run }}
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
       # Always runs first, regardless of dry_run, so the job log always shows
       # exactly which packages and versions are about to be published before
       # anything is actually pushed to pub.dev. melos only lists packages


### PR DESCRIPTION
## Why

The real publish run (`dry_run: false`) hung for 20 minutes and got cancelled, stuck on:

```
Pub needs your authorization to upload packages on your behalf.
In a web browser, go to https://accounts.google.com/o/oauth2/auth...
```

Nothing was actually published, no tags were created either, clean state.

## Root cause

`bluefireteam/melos-action@v3`'s `action.yml` only runs its `dart-lang/setup-dart` step (the one that wires up OIDC-based pub.dev auth, per that step's own name: "sets up the pipeline for usage with pub.dev (this sets up OIDC)") when its own `publish` input is `true`:

```yaml
- name: 'Installs the Dart SDK and sets up the pipeline for usage with pub.dev (this sets up OIDC)'
  if: ${{ inputs.publish == 'true' && inputs.dart-version != 'none' }}
  uses: dart-lang/setup-dart@...
```

That `publish: true` path is designed for melos-action's own single-package, tag-triggered publish flow (it extracts the package name from `refs/tags/<package>-v<version>`), which is not what our workflow does. We trigger via `workflow_dispatch` and run our own `melos publish` (potentially across several packages) as separate steps afterward, so that condition was never true, the OIDC setup step was always skipped, and `dart pub publish` fell back to interactive browser auth, which can never complete on a CI runner.

## Fix

Add the same `dart-lang/setup-dart@v1` step directly to this workflow, gated to real publishes only (`if: ${{ !inputs.dry_run }}`), right before our own `melos publish` steps. This is the same step melos-action would have run, just under our own control instead of tied to its unrelated `publish` input.

## Test plan
- [ ] Re-run "Publish to pub.dev" with `dry_run: false` and confirm it authenticates via OIDC without any interactive prompt
