### PR TITLE
fix(ci): trigger pub.dev publishing from tag pushes instead of workflow_dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,33 +1,49 @@
 name: Publish to pub.dev
 
+# pub.dev's Automated Publishing (OIDC-based, no stored credentials) only
+# accepts publish requests from a GitHub Actions run that was triggered by a
+# `push` of a git tag matching that package's configured tag pattern. It
+# rejects any run triggered by `workflow_dispatch`, with no way to opt out of
+# that restriction: https://dart.dev/go/publishing-from-github
+#
+# So this workflow is split into two jobs:
+#   - `prepare` (workflow_dispatch): figures out which packages have an
+#     unpublished local version and, unless dry_run, tags and pushes each one
+#     individually. It never talks to pub.dev itself.
+#   - `publish` (push of a matching tag): the only event pub.dev will accept.
+#     Publishes the single package named in the tag via OIDC.
+#
+# Each pushed tag triggers its own separate `publish` run. GitHub does not
+# deliver push events for tags when more than three are pushed in the same
+# `git push`, so `prepare` pushes tags one at a time rather than batching
+# them, otherwise some packages would silently never trigger a publish.
+
 on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Dry run (verify publishing without pushing to pub.dev)'
+        description: 'Dry run (preview only, does not create or push any tags)'
         type: boolean
         required: true
         default: true
-
-permissions:
-  contents: write
+  push:
+    tags:
+      - '*-v[0-9]+.[0-9]+.[0-9]+*'
 
 concurrency:
   group: publish-pub-dev
   cancel-in-progress: false
 
 jobs:
-  publish:
+  prepare:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
     permissions:
-      id-token: write
       contents: write
     steps:
       - uses: actions/checkout@v7
 
-      # melos publish creates an annotated git tag per published package
-      # (<package_name>-v<version>), which needs a committer identity.
       - name: Configure git identity for release tags
         run: |
           git config user.name "github-actions[bot]"
@@ -38,38 +54,62 @@ jobs:
           channel: stable
           cache: true
 
-      - run: flutter --version
       - run: flutter precache
-
       - uses: bluefireteam/melos-action@v3
 
-      # bluefireteam/melos-action only runs its own dart-lang/setup-dart step
-      # (the one that wires up OIDC-based pub.dev publishing) when its own
-      # `publish: true` input is set, which is meant for its single-package,
-      # tag-triggered publish flow, not our multi-package workflow_dispatch
-      # flow below. Without this, dart pub publish falls back to interactive
-      # browser OAuth, which can never complete on a CI runner.
-      - name: Set up Dart SDK for OIDC-based pub.dev publishing
-        if: ${{ !inputs.dry_run }}
-        uses: dart-lang/setup-dart@v1
-        with:
-          sdk: stable
-
-      # Always runs first, regardless of dry_run, so the job log always shows
-      # exactly which packages and versions are about to be published before
-      # anything is actually pushed to pub.dev. melos only lists packages
-      # whose local pubspec.yaml version is not yet published, every other
-      # package in the workspace is left untouched.
+      # Always runs, regardless of dry_run, so the job log always shows
+      # exactly which packages and versions are about to be released before
+      # any tag is created. melos only lists packages whose local
+      # pubspec.yaml version is not yet published, every other package in
+      # the workspace is left untouched.
       - name: Preview packages to be published
         run: melos publish --dry-run --yes
 
-      - name: Publish changed packages to pub.dev
+      # Compares each package's local version against the version currently
+      # on pub.dev directly (rather than relying on melos to both tag and
+      # publish together, which would hit the workflow_dispatch restriction
+      # above), and pushes one tag per unpublished package, one push at a
+      # time so every tag reliably triggers its own `publish` run below.
+      - name: Tag unpublished packages
         if: ${{ !inputs.dry_run }}
-        run: melos publish --no-dry-run --yes
+        run: |
+          set -euo pipefail
+          melos list --json | jq -c '.[]' | while read -r pkg; do
+            name=$(jq -r '.name' <<< "$pkg")
+            version=$(jq -r '.version' <<< "$pkg")
+            registry_version=$(curl -sf "https://pub.dev/api/packages/$name" | jq -r '.latest.version' 2>/dev/null || echo "")
+            if [ "$registry_version" = "$version" ]; then
+              continue
+            fi
+            tag="${name}-v${version}"
+            echo "Tagging and pushing $tag (pub.dev has ${registry_version:-nothing published yet})"
+            git tag "$tag"
+            git push origin "$tag"
+          done
 
-      # melos publish only creates these tags locally in the CI checkout, it
-      # never pushes them, so without this step every per-package release tag
-      # would be silently lost the moment the runner is torn down.
-      - name: Push release tags
-        if: ${{ !inputs.dry_run }}
-        run: git push origin --tags
+  publish:
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - run: flutter precache
+
+      # melos-action's own `publish: true` mode is exactly this flow: it
+      # extracts the package name from the triggering tag
+      # (refs/tags/<package>-v<version>), sets up a standalone Dart SDK via
+      # dart-lang/setup-dart for OIDC-based auth (Flutter's bundled Dart does
+      # not support automated publishing), then runs
+      # `melos publish -y --no-dry-run --scope=<package>`.
+      - uses: bluefireteam/melos-action@v3
+        with:
+          publish: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,13 @@ The following is a first version of guidelines for contributing to _File Picker_
 
 ## Releasing
 
-Publishing to pub.dev is a manual step, triggered from the "Publish to pub.dev" GitHub Actions workflow (`.github/workflows/publish.yml`) via "Run workflow". It runs `melos publish`, which only publishes the packages whose local `pubspec.yaml` version is not yet published on pub.dev, every other package in the workspace is left untouched. There is no single version number for the whole repository, each package releases independently whenever its own version is bumped.
+There is no single version number for the whole repository, each package releases independently whenever its own version is bumped.
 
-Before publishing for real, run the workflow once with the `dry_run` input left at its default (`true`) and check the job log, it lists exactly which packages and versions are about to be published. Once you are confident, run it again with `dry_run` set to `false`.
+pub.dev's Automated Publishing only accepts a publish request from a GitHub Actions run that was triggered by pushing a git tag matching that package's configured tag pattern, it rejects a run triggered by manually clicking "Run workflow" (`workflow_dispatch`), with no way to opt out. So releasing is a two-step process, both handled by the "Publish to pub.dev" workflow (`.github/workflows/publish.yml`):
 
-Every real (non-dry-run) publish also pushes a git tag per published package, named `<package_name>-v<version>` (e.g. `file_picker_darwin-v1.0.2`), pointing at the exact commit that was published. To check whether a given change made it into a published version of a package, find the tag for that version and see whether your commit is an ancestor of it (`git merge-base --is-ancestor <commit> <package_name>-v<version>`).
+1. **Prepare**: run the workflow via "Run workflow" with `dry_run` left at its default (`true`) first, and check the job log, it lists exactly which packages and versions would be released. Once you're confident, run it again with `dry_run` set to `false`. This does not talk to pub.dev, it only creates and pushes a git tag for each package with an unpublished local version, named `<package_name>-v<version>` (e.g. `file_picker_darwin-v1.0.2`), one push at a time (GitHub does not deliver push events for tags when more than three are pushed together, so batching them would silently drop some releases).
+2. **Publish**: each pushed tag triggers its own separate run of the same workflow, this time via the `push` event, which is what pub.dev actually requires. That run publishes only the one package named in its tag.
+
+A release touching several packages at once produces several tags and several parallel, independent publish runs, one per package, not one run publishing everything.
+
+To check whether a given change made it into a published version of a package, find the tag for that version and see whether your commit is an ancestor of it (`git merge-base --is-ancestor <commit> <package_name>-v<version>`).


### PR DESCRIPTION
## Why

The last real publish attempt (after fixing OIDC auth in #2168) got past authentication and was rejected by pub.dev itself:

```
ERROR: Insufficient permissions to the resource at the https://pub.dev package repository.
The calling GitHub Action is not allowed to publish, because: publishing is not allowed from 'workflow_dispath' events.
```

Per https://dart.dev/go/publishing-from-github, this is not a config issue, it is how pub.dev's Automated Publishing works everywhere: it only accepts a publish request from a run triggered by pushing a git tag matching that package's configured tag pattern, and rejects `workflow_dispatch`-triggered runs, with no opt-out.

## What

Splits `publish.yml` into two jobs:

- **`prepare`** (`workflow_dispatch`, same `dry_run` input as before): compares each package's local version against what's on pub.dev and, unless `dry_run`, tags and pushes each unpublished one individually. Never talks to pub.dev.
- **`publish`** (triggered by the resulting `push` of a tag matching `*-v[0-9]+.[0-9]+.[0-9]+*`): the only event pub.dev accepts. Uses `bluefireteam/melos-action`'s own `publish: true` mode, which extracts the package name from the tag and publishes just that one package via OIDC (this is also what wires up `dart-lang/setup-dart`, since Flutter's bundled Dart doesn't support automated publishing).

Tags are pushed one at a time, not batched in a single `git push --tags`, since GitHub does not deliver push events for tags when more than three are pushed together. A release touching several packages produces several tags and several independent, parallel publish runs.

Also fixes a `CONTRIBUTING.md` inaccuracy: it described `melos publish` as auto-tagging on every real publish. Checked melos's own source, `--git-tag-version` defaults to off, so that was never actually happening.

## Also needed on pub.dev (not part of this PR)

Each package's Automated Publishing config on pub.dev needs a `tag_pattern` set to `<package_name>-v{{version}}` (e.g. `file_picker_darwin-v{{version}}`), matching the tag format `prepare` creates.

## Test plan
- [x] `actionlint` passes on the workflow
- [x] Tag glob pattern verified against this repo's own history: the pre-#2151 workflow used the same `v[0-9]+.[0-9]+.[0-9]+*` syntax and it successfully triggered real releases (v11.0.2, the 12.0.0 betas, v12.0.0)
- [ ] Run `prepare` with `dry_run: false`, confirm each unpublished package gets tagged and pushed one at a time, and each tag's `publish` run succeeds
