### PR TITLE
fix(file_picker): bump to 12.1.1, 12.1.0 is already published

### DIFF
--- a/packages/file_picker/CHANGELOG.md
+++ b/packages/file_picker/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 12.1.1
+
+### macOS
+- Fixed `FilePicker.skipEntitlementsChecks()` being a permanent no-op. It now delegates to `FilePickerDarwin.skipEntitlementsChecks()` when running on macOS, so non-sandboxed apps can actually skip the App Sandbox entitlement checks again.
+
 ## 12.1.0
 
 ### General
@@ -5,9 +10,6 @@
 
 ### iOS
 - Fixed a crash (`FileSystemException`/`OSError: Is a directory`) when picking a Live Photo from the gallery. Live Photos are saved by iOS as `.pvt` packages (directories); the still image contained in the package is now extracted instead of returning the package itself.
-
-### macOS
-- Fixed `FilePicker.skipEntitlementsChecks()` being a permanent no-op. It now delegates to `FilePickerDarwin.skipEntitlementsChecks()` when running on macOS, so non-sandboxed apps can actually skip the App Sandbox entitlement checks again.
 
 ## 12.0.0
 

--- a/packages/file_picker/pubspec.yaml
+++ b/packages/file_picker/pubspec.yaml
@@ -9,7 +9,7 @@ topics:
   - storage
   - desktop
   - web
-version: 12.1.0
+version: 12.1.1
 
 resolution: workspace
 


### PR DESCRIPTION
## Why

#2166 merged after `file_picker` 12.1.0 had already been published to pub.dev manually. Its changelog entry landed inside the already-published `## 12.1.0` section without a version bump, which CONTRIBUTING.md's own rule says not to do (edit a published version's entry) instead of bumping to the next unpublished one.

## What

Moves the `skipEntitlementsChecks` delegation entry into its own `## 12.1.1` section and bumps `pubspec.yaml` to match. Patch bump, it's a bug fix, no breaking change.

## Test plan
- [x] `dart analyze` passes on `file_picker`
