### PR TITLE
docs(ci): note the shared concurrency group can silently stall a publish run

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,17 @@ concurrency:
   group: publish-pub-dev
   cancel-in-progress: false
 
+# This is a workflow level concurrency group, so it queues every run of this
+# workflow behind whatever is already in the group, regardless of which job
+# or trigger event it came from. If a run ever gets stuck in "queued" with no
+# jobs (a rare GitHub Actions scheduling issue, not something this workflow
+# controls), it can silently hold up every run behind it, including a real
+# tag push that should have triggered `publish`, with no visible error. If a
+# publish seems to be missing, check for a stuck queued run first
+# (https://github.com/miguelpruivo/flutter_file_picker/actions/workflows/publish.yml).
+# Dispatching any other run of this workflow has been observed to unstick the
+# queue.
+
 jobs:
   prepare:
     if: ${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
## Why

While testing the RELEASE_PAT fix from #2172 for real, a `workflow_dispatch` run got stuck in `queued` with no jobs (a GitHub Actions scheduling issue, not something under our control). Because `concurrency: group: publish-pub-dev` is declared at the workflow level, it queues every run of this workflow behind whatever else is in the group regardless of job or trigger event, so the stuck run silently held up a later real tag push too. `file_picker_darwin-v1.0.3` was tagged and pushed successfully, but no `publish` run appeared for over 15 minutes, with no error anywhere. It only started after dispatching an unrelated run of the same workflow, which seems to have nudged GitHub's queue. Once unstuck, `file_picker_darwin` 1.0.3 published successfully.

## What

Adds a comment next to the `concurrency:` block explaining this failure mode and the workaround (dispatch any run of the workflow to unstick the queue), so the next time a publish seems to be missing, whoever's looking doesn't have to rediscover this from scratch.

No behavior change.