### PR TITLE
docs: replace dead Wiki links with README pointers, restore verified setup notes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ labels: new issue
 
 ---
 
-Before creating an issue, make sure that you are on the latest `file_picker` version and that there aren't already any similar opened inssues. Also, check if it isn't described on the [Wiki](https://github.com/miguelpruivo/flutter_file_picker/wiki), specially on [Troubleshooting](https://github.com/miguelpruivo/flutter_file_picker/wiki/Troubleshooting) page.
+Before creating an issue, make sure that you are on the latest `file_picker` version and that there aren't already any similar opened issues.
 
 Also, sometimes a simple `flutter clean` and `flutter build` again with latest file_picker version, may end up by fixing cached issues, so I encourage you to first do so.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ labels: new issue
 
 ---
 
-Before creating an issue, make sure that you are on the latest `file_picker` version and that there aren't already any similar opened issues.
+Before creating an issue, make sure that you are on the latest `file_picker` version and that there aren't already any similar [opened issues](https://github.com/miguelpruivo/flutter_file_picker/issues).
 
 Also, sometimes a simple `flutter clean` and `flutter build` again with latest file_picker version, may end up by fixing cached issues, so I encourage you to first do so.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ See [`packages/file_picker/README.md`](packages/file_picker/README.md) for the f
 
 ## Documentation
 
-- [File Picker Wiki](https://github.com/miguelpruivo/flutter_file_picker/wiki) — installation, setup, and usage guides.
+- [`packages/file_picker/README.md`](packages/file_picker/README.md) for usage and the platform compatibility chart, and each platform package's own README for platform-specific setup (e.g. [`file_picker_darwin`](packages/file_picker_darwin/README.md) for macOS entitlements).
 - [API reference on pub.dev](https://pub.dev/documentation/file_picker/latest/file_picker/FilePicker-class.html).
 - [`packages/file_picker/CHANGELOG.md`](packages/file_picker/CHANGELOG.md) and each platform package's own `CHANGELOG.md` for release notes.
 

--- a/packages/file_picker/README.md
+++ b/packages/file_picker/README.md
@@ -47,7 +47,7 @@ If you have any feature that you want to see in this package, please feel free t
 | `pickFiles()`                 | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | `saveFile()`                  | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
-See the [API section of the File Picker Wiki](https://github.com/miguelpruivo/flutter_file_picker/wiki/api) or the [official API reference on pub.dev](https://pub.dev/documentation/file_picker/latest/file_picker/FilePicker-class.html) for further details.
+See the [official API reference on pub.dev](https://pub.dev/documentation/file_picker/latest/file_picker/FilePicker-class.html) for further details.
 
 ### Darwin implementation notes
 
@@ -81,7 +81,7 @@ Version 12.0 transitions `file_picker` to a **federated plugin architecture**.
      - `WebOptions` / `FilePickerWebOptions`
 
 ## Documentation
-See the **[File Picker Wiki](https://github.com/miguelpruivo/flutter_file_picker/wiki)** for details on installation, setup, and usage.
+For platform-specific setup, see the README of the platform package you're targeting (e.g. [`file_picker_darwin`](https://pub.dev/packages/file_picker_darwin) for macOS entitlements, [`android_file_picker`](https://pub.dev/packages/android_file_picker) for Android notes). For the full API, see the [official API reference on pub.dev](https://pub.dev/documentation/file_picker/latest/file_picker/FilePicker-class.html).
 
 ## Usage
 

--- a/packages/file_picker_android/README.md
+++ b/packages/file_picker_android/README.md
@@ -5,3 +5,7 @@ The Android implementation of `file_picker`.
 ## Usage
 
 This package is endorsed, which means you can simply use `file_picker` as normal, and the Android implementation will be automatically included.
+
+## Android setup
+
+If your app overrides `onActivityResult` in a custom `MainActivity`, make sure it calls `super.onActivityResult(...)` for activities it doesn't handle itself. Otherwise the plugin's own `onActivityResult` (in `FilePickerDelegate`) never runs, and picking a file fails silently.

--- a/packages/file_picker_darwin/README.md
+++ b/packages/file_picker_darwin/README.md
@@ -5,3 +5,23 @@ The iOS and macOS implementation of `file_picker`.
 ## Usage
 
 This package is endorsed, which means you can simply use `file_picker` as normal, and the iOS and macOS implementations will be automatically included.
+
+## macOS setup
+
+A sandboxed macOS app needs a files entitlement before the picker can return a usable path, without it every pick or save fails with an entitlement error. Add one of the following to both `macos/Runner/DebugProfile.entitlements` and `macos/Runner/Release.entitlements`, depending on whether your app only needs to read picked files or also needs to write to them:
+
+Read-only access:
+
+```xml
+<key>com.apple.security.files.user-selected.read-only</key>
+<true/>
+```
+
+Read and write access (required for `saveFile()`):
+
+```xml
+<key>com.apple.security.files.user-selected.read-write</key>
+<true/>
+```
+
+You can also add these from Xcode, under your target's *Signing & Capabilities* tab, in the *App Sandbox* section.


### PR DESCRIPTION
## Why

The Wiki was deleted following the discussion in #2156, but every link to it across the root README, the `file_picker` README, and the bug report template still pointed at it, all dead links now.

## What

- Replaced every Wiki link with pointers to the relevant README or the pub.dev API reference.
- Restored two setup notes that used to live only on the Wiki and have no other home, but only after verifying each against the current native implementations rather than copying the Wiki as is. The Wiki itself had gone stale (that mismatch is part of why it was removed, see the saveFile discussion in #2156), so copying it verbatim would have reintroduced the same problem:
  - **macOS**: the file access entitlements (`file_picker_darwin/README.md`). Verified these are still checked by name in `MacOSFilePickerHandler.swift`.
  - **Android**: the note about calling `super.onActivityResult()` in a custom `MainActivity` (`android_file_picker/README.md`). Verified `FilePickerDelegate` still relies on `onActivityResult` today.
- Deliberately did **not** carry over the Wiki's iOS `Info.plist` section (`NSAppleMusicUsageDescription`, `UIBackgroundModes`, `NSPhotoLibraryUsageDescription`). Checked `IOSFilePickerHandler.swift`: it uses `PHPickerViewController` and `UIDocumentPickerViewController` with `contentTypes: [.audio]`, neither of which needs those keys. That section was leftover from a much older implementation.

## Test plan

Docs only, no code changes.
- [x] Checked the whole repo for any remaining `flutter_file_picker/wiki` links outside of historical `CHANGELOG.md` entries (left those alone, changelogs are a historical record).