### PR TITLE
docs(file_picker): add the missing example

### DIFF
--- a/packages/file_picker/example/example.dart
+++ b/packages/file_picker/example/example.dart
@@ -1,0 +1,21 @@
+// An example demonstrating the usage of file_picker.
+import 'package:file_picker/file_picker.dart';
+
+Future<void> main() async {
+  // Pick a single file.
+  final PlatformFile? file = await FilePicker.pickFile();
+  if (file != null) {
+    print('Picked ${file.name} (${await file.length()} bytes).');
+  }
+
+  // Pick multiple files, filtered by extension.
+  final List<PlatformFile> images = await FilePicker.pickFiles(
+    type: FileType.custom,
+    allowedExtensions: ['png', 'jpg'],
+  );
+  print('Picked ${images.length} image(s).');
+
+  // Pick a directory.
+  final String? directoryPath = await FilePicker.getDirectoryPath();
+  print('Picked directory: $directoryPath');
+}


### PR DESCRIPTION
This is purely a pub.dev score fix, no behaviour change.

## What

Adds `packages/file_picker/example/example.dart`.

## Why

`file_picker` currently scores **120/160** on pub.dev, and 10 of the 40 missing points come from the Example section:

> **0/10 points: Package has an example**
> No example found.

pana looks for the example *inside the published package directory*. The workspace's example app lives at the repo root and is `publish_to: none`, so it is not part of the `file_picker` archive and pana never sees it.

Every other package in the workspace already solves this the same way:

| package | `example/example.dart` |
|---|---|
| `file_picker_platform_interface` | yes |
| `file_picker_android` | yes |
| `file_picker_darwin` | yes |
| `file_picker_linux` | yes |
| `file_picker_windows` | yes |
| `file_picker_web` | yes |
| **`file_picker`** | **missing** |

So this just restores consistency for the one package users actually depend on. It also fills in the currently empty Example tab on pub.dev.

The example follows the same shape as the existing six and demonstrates the three most common entry points of the facade: `pickFile`, `pickFiles` with an extension filter, and `getDirectoryPath`.

## Verification

- `dart format --output=none --set-exit-if-changed` — clean
- `flutter analyze` — no issues
- `flutter test` — passing
- `dart pub publish --dry-run` — 0 warnings, and `example/example.dart` is listed in the archive
