### PR TITLE
fix(file_picker): stop importing file_picker_darwin so the facade is wasm compatible

### DIFF
--- a/packages/file_picker/CHANGELOG.md
+++ b/packages/file_picker/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 12.1.2
+
+### General
+- Stopped importing `file_picker_darwin` directly from the facade package. `skipEntitlementsChecks()` now dispatches through the new `FilePickerPlatform.skipEntitlementsChecks()` hook instead of a type test on `FilePickerPlatform.instance`. That import pulled `dart:io` into `file_picker`'s import graph, making the package incompatible with wasm and breaking analysis when resolved against the lowest allowed dependency versions. No behavior change on any platform.
+
 ## 12.1.1
 
 ### macOS

--- a/packages/file_picker/lib/src/file_picker.dart
+++ b/packages/file_picker/lib/src/file_picker.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:android_file_picker/android_file_picker.dart';
-import 'package:file_picker_darwin/file_picker_darwin.dart';
 import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
 import 'package:flutter/foundation.dart';
 
@@ -257,8 +256,6 @@ abstract final class FilePicker {
   /// Note: skipping entitlement checks may lead to unexpected behavior if the
   /// app is actually sandboxed. Use with caution.
   static Future<void> skipEntitlementsChecks() async {
-    if (FilePickerPlatform.instance case final FilePickerDarwin instance) {
-      await instance.skipEntitlementsChecks();
-    }
+    await FilePickerPlatform.instance.skipEntitlementsChecks();
   }
 }

--- a/packages/file_picker/pubspec.yaml
+++ b/packages/file_picker/pubspec.yaml
@@ -21,9 +21,9 @@ dependencies:
   flutter:
     sdk: flutter
 
-  file_picker_platform_interface: ^3.1.0
+  file_picker_platform_interface: ^3.2.0
   android_file_picker: ^1.0.0
-  file_picker_darwin: ^1.0.0
+  file_picker_darwin: ^1.0.4
   file_picker_linux: ^1.0.0
   windows_file_picker: ^1.0.0
   file_picker_web: ^3.0.0

--- a/packages/file_picker/pubspec.yaml
+++ b/packages/file_picker/pubspec.yaml
@@ -9,7 +9,7 @@ topics:
   - storage
   - desktop
   - web
-version: 12.1.1
+version: 12.1.2
 
 resolution: workspace
 

--- a/packages/file_picker/test/file_picker_test.dart
+++ b/packages/file_picker/test/file_picker_test.dart
@@ -30,6 +30,13 @@ base class TestPlatformFile extends PlatformFile {
 
 class MockFilePickerPlatform extends FilePickerPlatform
     with MockPlatformInterfaceMixin {
+  bool skipEntitlementsChecksCalled = false;
+
+  @override
+  Future<void> skipEntitlementsChecks() async {
+    skipEntitlementsChecksCalled = true;
+  }
+
   @override
   Future<List<PlatformFile>> pickFiles({
     String? dialogTitle,
@@ -62,4 +69,14 @@ void main() {
       expect(files.first.path, '/path/to/test_file.txt');
     },
   );
+
+  test('FilePicker.skipEntitlementsChecks delegates to '
+      'FilePickerPlatform.instance.skipEntitlementsChecks', () async {
+    final mockPlatform = MockFilePickerPlatform();
+    FilePickerPlatform.instance = mockPlatform;
+
+    await FilePicker.skipEntitlementsChecks();
+
+    expect(mockPlatform.skipEntitlementsChecksCalled, isTrue);
+  });
 }

--- a/packages/file_picker_darwin/CHANGELOG.md
+++ b/packages/file_picker_darwin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+- `skipEntitlementsChecks()` now overrides the new `FilePickerPlatform.skipEntitlementsChecks()` hook instead of being called through a type test on `FilePickerPlatform.instance`. No behavior change on iOS or macOS.
+
 ## 1.0.3
 
 - Fixed a regression where `PrivacyInfo.xcprivacy` was never being bundled by Swift Package Manager, because SwiftPM resolves resource paths relative to the target's own directory. [#2175](https://github.com/miguelpruivo/flutter_file_picker/issues/2175)

--- a/packages/file_picker_darwin/lib/src/file_picker_darwin.dart
+++ b/packages/file_picker_darwin/lib/src/file_picker_darwin.dart
@@ -190,6 +190,7 @@ class FilePickerDarwin extends FilePickerPlatform {
   ///   await instance.skipEntitlementsChecks();
   /// }
   /// ```
+  @override
   Future<void> skipEntitlementsChecks() async {
     // Only macOS performs App Sandbox entitlement checks, this is a no-op on iOS.
     if (!Platform.isMacOS) return;

--- a/packages/file_picker_darwin/pubspec.yaml
+++ b/packages/file_picker_darwin/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_picker_darwin
 description: Darwin (iOS and macOS) implementation of the file_picker plugin, supporting native file picking, saving, and directory selection.
-version: 1.0.3
+version: 1.0.4
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_darwin
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_darwin
 topics:
@@ -31,7 +31,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  file_picker_platform_interface: ^3.0.0
+  file_picker_platform_interface: ^3.2.0
   cross_file: ^0.3.5+4
   path: ^1.9.0
 

--- a/packages/file_picker_platform_interface/CHANGELOG.md
+++ b/packages/file_picker_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.0
+
+- Added `FilePickerPlatform.skipEntitlementsChecks()`, a no-op default hook that platform implementations can override. Lets `file_picker` dispatch through the platform interface instead of importing `file_picker_darwin` directly, which kept the facade package from being wasm compatible.
+
 ## 3.1.0
 
 - Added `PlatformFile.extension`, restoring the pre-12.0 convenience getter that was dropped during the federated rewrite. Returns the file extension of `name` without the leading dot, or `null` if there is none.

--- a/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
+++ b/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
@@ -130,6 +130,13 @@ abstract class FilePickerPlatform extends PlatformInterface {
   /// Default implementation is a no-op for platforms that do not create temporary files.
   Future<void> clearTemporaryFiles() async {}
 
+  /// Asks the underlying platform to skip the App Sandbox entitlement checks
+  /// performed before showing a dialog.
+  ///
+  /// Default implementation is a no-op for platforms that do not perform
+  /// entitlement checks.
+  Future<void> skipEntitlementsChecks() async {}
+
   /// Save the given [bytes] to a file with the given [fileName], using the native save file dialog.
   ///
   /// The [fileName] parameter specifies the default file name for saving (e.g. `myFile.txt`).

--- a/packages/file_picker_platform_interface/pubspec.yaml
+++ b/packages/file_picker_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_picker_platform_interface
 description: A common platform interface for the file_picker plugin, defining the shared API surface and data contracts across platforms.
-version: 3.1.0
+version: 3.2.0
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_platform_interface
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_platform_interface
 topics:

--- a/packages/file_picker_platform_interface/test/file_picker_platform_interface_test.dart
+++ b/packages/file_picker_platform_interface/test/file_picker_platform_interface_test.dart
@@ -33,6 +33,7 @@ void main() {
         throwsUnimplementedError,
       );
       expect(instance.clearTemporaryFiles(), completes);
+      expect(instance.skipEntitlementsChecks(), completes);
       expect(() => instance.getDirectoryPath(), throwsUnimplementedError);
       expect(
         () => instance.saveFile(


### PR DESCRIPTION
This is purely a pub.dev score fix. No behaviour change on any platform.

Together with #2180 it takes `file_picker` from **120/160 to 160/160**. This PR is worth 30 of those 40 points.

## The problem

`file_picker` is the app-facing package of a federated plugin, so it should only ever import the platform *interface*. It also imports the macOS/iOS *implementation* directly, and only for one thing, the type test in `skipEntitlementsChecks()`:

```dart
import 'package:file_picker_darwin/file_picker_darwin.dart';
...
static Future<void> skipEntitlementsChecks() async {
  if (FilePickerPlatform.instance case final FilePickerDarwin instance) {
    await instance.skipEntitlementsChecks();
  }
}
```

That single import drags `dart:io` into the facade's import graph. It costs two separate score sections:

**1. Platform support, 10/20.** pana's trace on 12.1.1:

```
Package not compatible with runtime wasm
Because:
* package:file_picker/file_picker.dart that imports:
* package:file_picker/src/file_picker.dart that imports:
* package:file_picker_darwin/file_picker_darwin.dart that imports:
* package:file_picker_darwin/src/file_picker_darwin.dart that imports:
* dart:io
```

Worth stressing: nothing in this workspace is actually web-unclean. `file_picker_web` already uses `package:web`, and `file_picker_platform_interface` already guards its own `dart:io` behind a conditional export. The facade's import is the only thing standing between this package and `is:wasm-ready`.

**2. Dependency lower bounds, 0/20.** The same type test is the *sole* error in the downgrade analysis:

```
UNDEFINED_METHOD - lib/src/file_picker.dart:261:22
- The method 'skipEntitlementsChecks' isn't defined for the type 'FilePickerDarwin'.
```

## The fix

Route the call through the platform interface, following the `clearTemporaryFiles()` hook that already exists a few lines above:

- `file_picker_platform_interface`: add `Future<void> skipEntitlementsChecks() async {}`, a default no-op
- `file_picker_darwin`: mark its existing method `@override`, body untouched
- `file_picker`: drop the import, dispatch on `FilePickerPlatform.instance`

Behaviour is identical. Before, a non-Darwin platform fell through the type test and did nothing; now it hits the interface no-op and does nothing. On macOS the same `FilePickerDarwin` method runs, and its `if (!Platform.isMacOS) return;` guard is untouched.

## On the version constraints

`file_picker` now requires `file_picker_darwin: ^1.0.4` rather than `^1.0.0`, and that bound is load-bearing. With the old bound, an older `file_picker_darwin` would not override the new hook, so `skipEntitlementsChecks()` would silently fall back to the interface no-op on macOS, which is exactly the regression 12.1.1 fixed. The two implementation packages are bumped to `3.2.0` and `1.0.4` so those constraints resolve; publishing them before `file_picker` is what makes the bound valid on pub.dev.

I left `file_picker`'s own version and all three `CHANGELOG.md` files alone, so this slots into whatever release shape you want.

## Verification

- `dart format --output=none --set-exit-if-changed` on `packages/` — clean
- `flutter analyze` on all three changed packages — no issues. The `@override` resolving is itself proof the new hook is wired correctly.
- `flutter test` on all three — passing, including two new tests: the default no-op on the interface, and that `FilePicker.skipEntitlementsChecks()` actually reaches the platform instance. That second one is a regression test for the bug fixed in 12.1.1, where this method was a permanent no-op.
- WASM: I reproduced pana's reachability analysis locally and validated it by reproducing the published 12.1.1 trace above chain-for-chain on `master`. On this branch `dart:io` is no longer reachable from `package:file_picker/file_picker.dart`.