### PR TITLE
chore: prepare next release across all packages

### DIFF
--- a/packages/file_picker/CHANGELOG.md
+++ b/packages/file_picker/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### General
 - Stopped importing `file_picker_darwin` directly from the facade package. `skipEntitlementsChecks()` now dispatches through the new `FilePickerPlatform.skipEntitlementsChecks()` hook instead of a type test on `FilePickerPlatform.instance`. That import pulled `dart:io` into `file_picker`'s import graph, making the package incompatible with wasm and breaking analysis when resolved against the lowest allowed dependency versions. No behavior change on any platform.
 
+### iOS
+- Added `darwinOptions` (`DarwinOptions`) to `pickFile()`/`pickFiles()`, letting callers set `DarwinAssetRepresentationMode` to request the photo library return media in its `current` or a `compatible` representation instead of always transcoding to the system default (`automatic`). Restores a way to avoid expensive transcoding for large HEVC, HDR, or slow-motion videos, which existed before the Darwin implementation was rewritten. Non-automatic modes require `compressionQuality: 0`, mixing the two throws an `ArgumentError`.
+
 ## 12.1.1
 
 ### macOS

--- a/packages/file_picker/lib/src/file_picker.dart
+++ b/packages/file_picker/lib/src/file_picker.dart
@@ -259,7 +259,10 @@ abstract final class FilePicker {
   /// and would otherwise be incorrectly blocked by those checks. Call this before
   /// any other file picking method.
   ///
-  /// This method does nothing on platforms other than macOS.
+  /// Delegates to `FilePickerPlatform.instance.skipEntitlementsChecks()`,
+  /// whose default implementation is a no-op. Only `FilePickerDarwin`
+  /// overrides it, and only macOS performs the check in the first place, so
+  /// this method does nothing on platforms other than macOS.
   ///
   /// Note: skipping entitlement checks may lead to unexpected behavior if the
   /// app is actually sandboxed. Use with caution.

--- a/packages/file_picker_android/CHANGELOG.md
+++ b/packages/file_picker_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+- Tightened the `file_picker_platform_interface` lower bound to `^3.2.0`. This package's `pickFile()`/`pickFiles()` signatures reference `DarwinOptions`, added in that version, so resolving against an older one would fail to compile.
+
 ## 1.0.2
 
 - Removed the stale `buildscript` classpath from the Android module, which pinned AGP 8.5.2 and Kotlin Gradle Plugin 1.8.22 in a module that supports AGP 9 and Kotlin 2.3. [#2154](https://github.com/miguelpruivo/flutter_file_picker/pull/2154)

--- a/packages/file_picker_android/pubspec.yaml
+++ b/packages/file_picker_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: android_file_picker
 description: Android implementation of the file_picker plugin, supporting file picking, saving, and Storage Access Framework (SAF) URI grants.
-version: 1.0.2
+version: 1.0.3
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_android
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_android
 topics:
@@ -25,7 +25,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  file_picker_platform_interface: ^3.0.0
+  file_picker_platform_interface: ^3.2.0
   cross_file: ^0.3.5+4
   path: ^1.9.0
 

--- a/packages/file_picker_darwin/CHANGELOG.md
+++ b/packages/file_picker_darwin/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.4
 
 - `skipEntitlementsChecks()` now overrides the new `FilePickerPlatform.skipEntitlementsChecks()` hook instead of being called through a type test on `FilePickerPlatform.instance`. No behavior change on iOS or macOS.
+- Added `DarwinOptions.assetRepresentationMode` support on iOS, mapped to `PHPickerConfiguration.preferredAssetRepresentationMode`. Requesting `current` or `compatible` lets large HEVC, HDR, or slow-motion videos skip the transcoding `automatic` (the default) would otherwise require. Non-automatic modes require `compressionQuality` to be `0`.
 
 ## 1.0.3
 

--- a/packages/file_picker_darwin/test/file_picker_darwin_test.dart
+++ b/packages/file_picker_darwin/test/file_picker_darwin_test.dart
@@ -61,21 +61,22 @@ void main() {
     );
 
     test('rejects non-automatic representation with compression', () {
+      final picker = FilePickerDarwin();
+      const darwinOptions = DarwinOptions(
+        assetRepresentationMode: DarwinAssetRepresentationMode.current,
+      );
+
       expect(
-        () => FilePickerDarwin().pickFile(
+        () => picker.pickFile(
           compressionQuality: 50,
-          darwinOptions: const DarwinOptions(
-            assetRepresentationMode: DarwinAssetRepresentationMode.current,
-          ),
+          darwinOptions: darwinOptions,
         ),
         throwsArgumentError,
       );
       expect(
-        () => FilePickerDarwin().pickFiles(
+        () => picker.pickFiles(
           compressionQuality: 50,
-          darwinOptions: const DarwinOptions(
-            assetRepresentationMode: DarwinAssetRepresentationMode.current,
-          ),
+          darwinOptions: darwinOptions,
         ),
         throwsArgumentError,
       );

--- a/packages/file_picker_darwin/test/file_picker_darwin_test.dart
+++ b/packages/file_picker_darwin/test/file_picker_darwin_test.dart
@@ -62,6 +62,15 @@ void main() {
 
     test('rejects non-automatic representation with compression', () {
       expect(
+        () => FilePickerDarwin().pickFile(
+          compressionQuality: 50,
+          darwinOptions: const DarwinOptions(
+            assetRepresentationMode: DarwinAssetRepresentationMode.current,
+          ),
+        ),
+        throwsArgumentError,
+      );
+      expect(
         () => FilePickerDarwin().pickFiles(
           compressionQuality: 50,
           darwinOptions: const DarwinOptions(

--- a/packages/file_picker_linux/CHANGELOG.md
+++ b/packages/file_picker_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+- Tightened the `file_picker_platform_interface` lower bound to `^3.2.0`. This package's `pickFile()`/`pickFiles()` signatures reference `DarwinOptions`, added in that version, so resolving against an older one would fail to compile.
+
 ## 1.0.1
 
 - Relax `dbus` to `^0.7.13` so dependents can resolve `xml` 7. [#2130](https://github.com/miguelpruivo/flutter_file_picker/issues/2130)

--- a/packages/file_picker_linux/pubspec.yaml
+++ b/packages/file_picker_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_picker_linux
 description: Linux implementation of the file_picker plugin using GTK3 and XDG Desktop Portals for native file and directory picking.
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_linux
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_linux
 topics:
@@ -23,7 +23,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  file_picker_platform_interface: ^3.0.0
+  file_picker_platform_interface: ^3.2.0
   cross_file: ^0.3.5+4
   dbus: ^0.7.13
   path: ^1.9.0

--- a/packages/file_picker_platform_interface/CHANGELOG.md
+++ b/packages/file_picker_platform_interface/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.2.0
 
 - Added `FilePickerPlatform.skipEntitlementsChecks()`, a no-op default hook that platform implementations can override. Lets `file_picker` dispatch through the platform interface instead of importing `file_picker_darwin` directly, which kept the facade package from being wasm compatible.
+- Added `DarwinOptions` and `DarwinAssetRepresentationMode`, letting callers request a specific asset representation (`current` or `compatible`) for media selected from the iOS photo library, instead of always using the system default (`automatic`). Restores functionality that was available before the Darwin implementation was rewritten (previously exposed as a way to disable compression), useful to avoid expensive transcoding for large HEVC, HDR, or slow-motion videos.
 
 ## 3.1.0
 

--- a/packages/file_picker_web/CHANGELOG.md
+++ b/packages/file_picker_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.3
+
+- Tightened the `file_picker_platform_interface` lower bound to `^3.2.0`. This package's `pickFile()`/`pickFiles()` signatures reference `DarwinOptions`, added in that version, so resolving against an older one would fail to compile.
+
 ## 3.0.2
 
 - Fixed the `window` `focus` listener used to detect a cancelled picker dialog never being removed after use. `removeEventListener` was passed a freshly created `.toJS` function object on every call, which never matches the one originally passed to `addEventListener`, so the listener leaked on `window` on every `pickFiles`/`pickFile` call. The JS function references are now cached and reused for both add and remove.

--- a/packages/file_picker_web/pubspec.yaml
+++ b/packages/file_picker_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_picker_web
 description: Web platform implementation of the file_picker plugin, providing browser file selection, file streaming, and file loading.
-version: 3.0.2
+version: 3.0.3
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_web
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_web
 topics:
@@ -26,7 +26,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  file_picker_platform_interface: ^3.0.0
+  file_picker_platform_interface: ^3.2.0
   cross_file: ^0.3.5+4
   meta: ^1.17.0
   path: ^1.9.1

--- a/packages/file_picker_windows/CHANGELOG.md
+++ b/packages/file_picker_windows/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Migrated `pickFile()`, `pickFiles()`, and `saveFile()` from the legacy `GetOpenFileNameW`/`GetSaveFileNameW` common dialogs to the modern `IFileOpenDialog`/`IFileSaveDialog` COM APIs, the same pattern `getDirectoryPath()` already used. This is a prerequisite for supporting custom dialog button text and other Common Item Dialog features on those entry points. Fixes [#2173](https://github.com/miguelpruivo/flutter_file_picker/issues/2173).
 - Removed the internal Win32 helpers tied to the legacy dialogs (`fileTypeToFileFilter`, `extractSelectedFilesFromOpenFileNameW`, `OPENFILENAMEW`, `GetOpenFileNameW`, `GetSaveFileNameW`, and the `ofn*` constants). These were implementation details of the removed dialog code, not part of the supported plugin API.
+- Tightened the `file_picker_platform_interface` lower bound to `^3.2.0`. This package's `pickFile()`/`pickFiles()` signatures reference `DarwinOptions`, added in that version, so resolving against an older one would fail to compile.
 
 ## 1.0.2
 

--- a/packages/file_picker_windows/pubspec.yaml
+++ b/packages/file_picker_windows/pubspec.yaml
@@ -23,7 +23,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  file_picker_platform_interface: ^3.0.0
+  file_picker_platform_interface: ^3.2.0
   cross_file: ^0.3.5+4
   ffi: ^2.2.0
   meta: ^1.17.0


### PR DESCRIPTION
## What this ships

Every package in the workspace currently has an unpublished version pending on `master`. This PR fixes the last gap (a missing changelog entry and a broken dependency lower bound from #2177) that was blocking a clean release, so once it merges every package below is ready to publish via the "Publish to pub.dev" workflow.

| Package | Published | Next | Highlights |
|---|---|---|---|
| `file_picker` | 12.1.1 | **12.1.2** | Facade no longer imports `file_picker_darwin` directly (wasm compatible again, #2181). Adds `darwinOptions` to `pickFile()`/`pickFiles()`. |
| `file_picker_platform_interface` | 3.1.0 | **3.2.0** | Adds `FilePickerPlatform.skipEntitlementsChecks()` and `DarwinOptions`/`DarwinAssetRepresentationMode`. |
| `file_picker_darwin` | 1.0.3 | **1.0.4** | `skipEntitlementsChecks()` now overrides the interface hook. iOS: `DarwinAssetRepresentationMode` support via `PHPickerConfiguration.preferredAssetRepresentationMode`, avoids forced transcoding for large HEVC/HDR/slow-motion videos (#2177). |
| `windows_file_picker` | 1.0.2 | **1.1.0** | `pickFile()`/`pickFiles()`/`saveFile()` migrated from legacy `GetOpenFileNameW`/`GetSaveFileNameW` to `IFileOpenDialog`/`IFileSaveDialog` (#2173/#2174). |
| `android_file_picker` | 1.0.2 | **1.0.3** *(this PR)* | Dependency correctness fix: `file_picker_platform_interface` lower bound tightened to `^3.2.0`. |
| `file_picker_web` | 3.0.2 | **3.0.3** *(this PR)* | Same dependency fix. |
| `file_picker_linux` | 1.0.1 | **1.0.2** *(this PR)* | Same dependency fix. |

## Why the last three needed a bump here

#2177 referenced the new `DarwinOptions` type in every implementation package's `pickFile()`/`pickFiles()` signature, but `android_file_picker`, `file_picker_web`, `windows_file_picker`, and `file_picker_linux` still constrained `file_picker_platform_interface` to `^3.0.0`, a version that predates `DarwinOptions`. Resolving any of them against the lowest allowed interface version would fail to compile, the same class of bug fixed for the wasm/downgrade case in #2181. `windows_file_picker` was already getting a real bump from #2174, so its fix folds into that; the other three are otherwise unchanged since their last release, so this is their only reason to bump.

## Test plan

- [x] `flutter analyze` across the whole workspace, clean
- [x] `dart format --output=none --set-exit-if-changed`, clean
- [x] `flutter test` across the whole workspace, all 48 tests pass