### PR TITLE
fix(ci): scope publish concurrency per tag instead of one group for everything

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,21 +30,6 @@ on:
     tags:
       - '*-v[0-9]+.[0-9]+.[0-9]+*'
 
-concurrency:
-  group: publish-pub-dev
-  cancel-in-progress: false
-
-# This is a workflow level concurrency group, so it queues every run of this
-# workflow behind whatever is already in the group, regardless of which job
-# or trigger event it came from. If a run ever gets stuck in "queued" with no
-# jobs (a rare GitHub Actions scheduling issue, not something this workflow
-# controls), it can silently hold up every run behind it, including a real
-# tag push that should have triggered `publish`, with no visible error. If a
-# publish seems to be missing, check for a stuck queued run first
-# (https://github.com/miguelpruivo/flutter_file_picker/actions/workflows/publish.yml).
-# Dispatching any other run of this workflow has been observed to unstick the
-# queue.
-
 jobs:
   prepare:
     if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -52,6 +37,16 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+    # Only serializes against other `prepare` runs (which read and write git
+    # tags and unpublished-package state, so two running at once could race).
+    # Deliberately job scoped rather than workflow scoped: `publish` runs
+    # have their own concurrency group below, so a `prepare` run stuck
+    # queued (a rare GitHub Actions scheduling issue, not something this
+    # workflow controls) can no longer silently hold up every tag's publish
+    # behind it, which is what happened before this was split.
+    concurrency:
+      group: publish-pub-dev-prepare
+      cancel-in-progress: false
     steps:
       # GitHub does not run other workflows off a push made with the default
       # GITHUB_TOKEN (it is a deliberate anti-recursion guard), so a tag this
@@ -107,6 +102,15 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    # Scoped to the triggering tag itself, so each package's publish is
+    # independent of every other package's. This only serializes reruns of
+    # the exact same tag against each other; it never queues one package's
+    # publish behind another's the way a single workflow wide group did.
+    # That is what let a `prepare` run stuck queued cancel six of seven
+    # publish runs when this workflow released every package at once.
+    concurrency:
+      group: publish-pub-dev-${{ github.ref_name }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## Why

Just released all 7 packages at once (#2182). Six of the seven `publish` runs got cancelled seconds after being created, before a single job step ran. Only the seventh, whose tag happened to land last, actually published. All 6 had to be manually rerun via `gh run rerun` to actually publish, and they succeeded once rerun individually.

What's confirmed: `concurrency: group: publish-pub-dev` was declared at the workflow level, so every run of this workflow shared it regardless of job, `prepare` and `publish` included. A `prepare` run from an earlier session has been stuck in `queued` with no jobs for two days, `gh run cancel` refuses it with "not been queued yet", and it sat in that same shared group the whole time. `prepare` tagged and pushed all 7 packages within about 8 seconds, and all 7 `publish` runs landed in that same poisoned group right after.

I can't point to GitHub documentation for the exact internal mechanism that turned "queue behind a stuck entry" into "cancel the backlog" here, so I'm not claiming certainty on that specific step, only that this is what the timeline and the stuck run's presence in the shared group point to, and it's consistent with every run rerunning cleanly once removed from that group's blast radius.

What I am sure of, independent of the exact mechanism: this design had two structural problems regardless of the stuck run:
1. `prepare` and `publish` are different jobs with no reason to share a concurrency relationship, one tags, the other publishes.
2. Different packages' `publish` runs have no reason to serialize against each other either, they're independent releases to independent pub.dev packages.

## What

- Moved `concurrency` from the workflow level down into each job.
- `prepare`: `publish-pub-dev-prepare`, only serializes against other `prepare` runs (which do read/write shared git tag state, so that part of the original intent is kept).
- `publish`: `publish-pub-dev-${{ github.ref_name }}`, scoped to the triggering tag. Only serializes a rerun of the exact same tag against itself; never queues one package behind another.

With this in place, a stuck `prepare` run can still block other `prepare` runs, but it can never again cancel or delay a `publish` run for any package, whatever the exact GitHub-side mechanism turns out to be.

## Test plan

- [x] `actionlint` clean
- Can't fully dry-run concurrency behavior without another real multi-tag release, the reasoning above is what actually happened today and what the new scoping addresses. Any future release naturally re-validates this.