### PR TITLE
feat(platform_interface): add PlatformFile.size

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,8 +136,9 @@ jobs:
           # since every package here declares `resolution: workspace` and pub
           # then refuses to resolve the facade itself. So this check waits for
           # the release. `tool/test/facade_constraints_test.dart` covers the
-          # same mistake without needing pub.dev, and does run on release
-          # branches.
+          # pairing this build cannot produce anyway, the newest interface next
+          # to the oldest allowed implementation, and it reads that from
+          # pub.dev rather than from a resolution.
           unpublished=""
           for dir in "$GITHUB_WORKSPACE"/packages/*/; do
             name=$(sed -n 's/^name: *//p' "$dir/pubspec.yaml" | head -1)

--- a/packages/file_picker/CHANGELOG.md
+++ b/packages/file_picker/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 12.2.0
 
 ### General
-- `PlatformFile.size` is back. It returns the size the native picker already reported, without any I/O, or `null` when the platform did not report one, in which case `length()` still reads it from disk. [#2187](https://github.com/vicajilau/flutter_file_picker/issues/2187)
-- Raised the lower bounds on the platform implementations and the platform interface together. `PlatformFile.size` is abstract, so an implementation published before it does not satisfy the new interface, and leaving the old bounds would let pub resolve a combination that compiles nowhere.
+- Added `PlatformFile.lengthSync()`, replacing the `size` property removed in 12.0. It returns the length the native picker already reported, without any I/O, or `null` when the platform did not report one, in which case `length()` still reads it from disk. [#2187](https://github.com/vicajilau/flutter_file_picker/issues/2187)
+- Raised the lower bounds on the platform implementations and the platform interface together. `PlatformFile.lengthSync()` is abstract, so an implementation published before it does not satisfy the new interface, and leaving the old bounds would let pub resolve a combination that compiles nowhere.
 
 ## 12.1.3
 

--- a/packages/file_picker/CHANGELOG.md
+++ b/packages/file_picker/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 12.2.0
+
+### General
+- `PlatformFile.size` is back. It returns the size the native picker already reported, without any I/O, or `null` when the platform did not report one, in which case `length()` still reads it from disk. [#2187](https://github.com/vicajilau/flutter_file_picker/issues/2187)
+- Raised the lower bounds on the platform implementations and the platform interface together. `PlatformFile.size` is abstract, so an implementation published before it does not satisfy the new interface, and leaving the old bounds would let pub resolve a combination that compiles nowhere.
+
 ## 12.1.3
 
 ### General

--- a/packages/file_picker/pubspec.yaml
+++ b/packages/file_picker/pubspec.yaml
@@ -9,7 +9,7 @@ topics:
   - storage
   - desktop
   - web
-version: 12.1.3
+version: 12.2.0
 
 resolution: workspace
 
@@ -21,12 +21,12 @@ dependencies:
   flutter:
     sdk: flutter
 
-  file_picker_platform_interface: ^3.2.0
-  android_file_picker: ^1.0.3
-  file_picker_darwin: ^1.0.4
-  file_picker_linux: ^1.0.2
-  windows_file_picker: ^1.1.0
-  file_picker_web: ^3.0.3
+  file_picker_platform_interface: ^3.3.0
+  android_file_picker: ^1.1.0
+  file_picker_darwin: ^1.1.0
+  file_picker_linux: ^1.1.0
+  windows_file_picker: ^1.2.0
+  file_picker_web: ^3.1.0
   cross_file: ^0.3.5+4
 
 dev_dependencies:

--- a/packages/file_picker/test/file_picker_test.dart
+++ b/packages/file_picker/test/file_picker_test.dart
@@ -19,7 +19,7 @@ base class TestPlatformFile extends PlatformFile {
   XFile get xFile => XFile(path ?? '');
 
   @override
-  int? get size => 100;
+  int? lengthSync() => 100;
 
   @override
   Future<int> length() async => 100;

--- a/packages/file_picker/test/file_picker_test.dart
+++ b/packages/file_picker/test/file_picker_test.dart
@@ -19,6 +19,9 @@ base class TestPlatformFile extends PlatformFile {
   XFile get xFile => XFile(path ?? '');
 
   @override
+  int? get size => 100;
+
+  @override
   Future<int> length() async => 100;
 
   @override

--- a/packages/file_picker_android/CHANGELOG.md
+++ b/packages/file_picker_android/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.1.0
 
-- Implemented `PlatformFile.size`, returning the size Android already reports for a picked file synchronously.
+- Implemented `PlatformFile.lengthSync()`, returning the length Android already reports for a picked file synchronously.
 
 ## 1.0.4
 

--- a/packages/file_picker_android/CHANGELOG.md
+++ b/packages/file_picker_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- Implemented `PlatformFile.size`, returning the size Android already reports for a picked file synchronously, without doing any I/O.
+
 ## 1.0.3
 
 - Tightened the `file_picker_platform_interface` lower bound to `^3.2.0`. This package's `pickFile()`/`pickFiles()` signatures reference `DarwinOptions`, added in that version, so resolving against an older one would fail to compile.

--- a/packages/file_picker_android/CHANGELOG.md
+++ b/packages/file_picker_android/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.1.0
 
-- Implemented `PlatformFile.size`, returning the size Android already reports for a picked file synchronously, without doing any I/O.
+- Implemented `PlatformFile.size`, returning the size Android already reports for a picked file synchronously.
 
 ## 1.0.3
 

--- a/packages/file_picker_android/lib/src/android_platform_file.dart
+++ b/packages/file_picker_android/lib/src/android_platform_file.dart
@@ -81,6 +81,12 @@ base class AndroidPlatformFile extends PlatformFile {
   }
 
   @override
+  int? get size {
+    final len = _bytesLength;
+    return (len != null && len > 0) ? len : null;
+  }
+
+  @override
   Future<int> length() async {
     final len = _bytesLength;
     if (len != null && len > 0) return len;

--- a/packages/file_picker_android/lib/src/android_platform_file.dart
+++ b/packages/file_picker_android/lib/src/android_platform_file.dart
@@ -82,7 +82,7 @@ base class AndroidPlatformFile extends PlatformFile {
 
   /// The size Android already reported for this file when it was picked.
   @override
-  int? get size {
+  int? lengthSync() {
     final len = _bytesLength;
     return (len != null && len > 0) ? len : null;
   }

--- a/packages/file_picker_android/lib/src/android_platform_file.dart
+++ b/packages/file_picker_android/lib/src/android_platform_file.dart
@@ -80,6 +80,7 @@ base class AndroidPlatformFile extends PlatformFile {
     return XFile(uri.toString(), name: name);
   }
 
+  /// The size Android already reported for this file when it was picked.
   @override
   int? get size {
     final len = _bytesLength;

--- a/packages/file_picker_android/pubspec.yaml
+++ b/packages/file_picker_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: android_file_picker
 description: Android implementation of the file_picker plugin, supporting file picking, saving, and Storage Access Framework (SAF) URI grants.
-version: 1.0.3
+version: 1.1.0
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_android
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_android
 topics:
@@ -25,7 +25,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  file_picker_platform_interface: ^3.2.0
+  file_picker_platform_interface: ^3.3.0
   cross_file: ^0.3.5+4
   path: ^1.9.0
 

--- a/packages/file_picker_android/test/file_picker_android_test.dart
+++ b/packages/file_picker_android/test/file_picker_android_test.dart
@@ -42,17 +42,17 @@ void main() {
       expect(file.path, equals('/tmp/test_file.txt'));
     });
 
-    test('AndroidPlatformFile.size reflects the reported size', () {
+    test('AndroidPlatformFile.lengthSync() reflects the reported size', () {
       final withSize = AndroidPlatformFile.fromMap({
         'path': '/tmp/test_file.txt',
         'size': 2048,
       });
-      expect(withSize.size, equals(2048));
+      expect(withSize.lengthSync(), equals(2048));
 
       final withoutSize = AndroidPlatformFile.fromMap({
         'path': '/tmp/test_file.txt',
       });
-      expect(withoutSize.size, isNull);
+      expect(withoutSize.lengthSync(), isNull);
     });
 
     test('AndroidPlatformFile throws ArgumentError on empty path and uri', () {

--- a/packages/file_picker_android/test/file_picker_android_test.dart
+++ b/packages/file_picker_android/test/file_picker_android_test.dart
@@ -42,6 +42,19 @@ void main() {
       expect(file.path, equals('/tmp/test_file.txt'));
     });
 
+    test('AndroidPlatformFile.size reflects the reported size', () {
+      final withSize = AndroidPlatformFile.fromMap({
+        'path': '/tmp/test_file.txt',
+        'size': 2048,
+      });
+      expect(withSize.size, equals(2048));
+
+      final withoutSize = AndroidPlatformFile.fromMap({
+        'path': '/tmp/test_file.txt',
+      });
+      expect(withoutSize.size, isNull);
+    });
+
     test('AndroidPlatformFile throws ArgumentError on empty path and uri', () {
       expect(() => AndroidPlatformFile.fromMap({}), throwsArgumentError);
     });

--- a/packages/file_picker_darwin/CHANGELOG.md
+++ b/packages/file_picker_darwin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- Implemented `PlatformFile.size`, returning the size iOS/macOS already reports for a picked file synchronously, without doing any I/O.
+
 ## 1.0.4
 
 - `skipEntitlementsChecks()` now overrides the new `FilePickerPlatform.skipEntitlementsChecks()` hook instead of being called through a type test on `FilePickerPlatform.instance`. No behavior change on iOS or macOS.

--- a/packages/file_picker_darwin/CHANGELOG.md
+++ b/packages/file_picker_darwin/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.1.0
 
-- Implemented `PlatformFile.size`, returning the size iOS/macOS already reports for a picked file synchronously, without doing any I/O.
+- Implemented `PlatformFile.lengthSync()`, returning the length iOS/macOS already reports for a picked file synchronously, without doing any I/O.
 
 ## 1.0.4
 

--- a/packages/file_picker_darwin/lib/src/darwin_platform_file.dart
+++ b/packages/file_picker_darwin/lib/src/darwin_platform_file.dart
@@ -67,7 +67,7 @@ base class DarwinPlatformFile extends PlatformFile {
 
   /// The size iOS/macOS already reported for this file when it was picked.
   @override
-  int? get size {
+  int? lengthSync() {
     final len = _bytesLength;
     return (len != null && len > 0) ? len : null;
   }

--- a/packages/file_picker_darwin/lib/src/darwin_platform_file.dart
+++ b/packages/file_picker_darwin/lib/src/darwin_platform_file.dart
@@ -65,6 +65,7 @@ base class DarwinPlatformFile extends PlatformFile {
     return XFile(uri.toString(), name: name);
   }
 
+  /// The size iOS/macOS already reported for this file when it was picked.
   @override
   int? get size {
     final len = _bytesLength;

--- a/packages/file_picker_darwin/lib/src/darwin_platform_file.dart
+++ b/packages/file_picker_darwin/lib/src/darwin_platform_file.dart
@@ -66,6 +66,12 @@ base class DarwinPlatformFile extends PlatformFile {
   }
 
   @override
+  int? get size {
+    final len = _bytesLength;
+    return (len != null && len > 0) ? len : null;
+  }
+
+  @override
   Future<int> length() async {
     final len = _bytesLength;
     if (len != null && len > 0) return len;

--- a/packages/file_picker_darwin/pubspec.yaml
+++ b/packages/file_picker_darwin/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_picker_darwin
 description: Darwin (iOS and macOS) implementation of the file_picker plugin, supporting native file picking, saving, and directory selection.
-version: 1.0.4
+version: 1.1.0
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_darwin
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_darwin
 topics:
@@ -31,7 +31,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  file_picker_platform_interface: ^3.2.0
+  file_picker_platform_interface: ^3.3.0
   cross_file: ^0.3.5+4
   path: ^1.9.0
 

--- a/packages/file_picker_darwin/test/file_picker_darwin_test.dart
+++ b/packages/file_picker_darwin/test/file_picker_darwin_test.dart
@@ -23,6 +23,15 @@ void main() {
       });
       expect(file.name, equals('test.png'));
       expect(file.uri.path, equals('/tmp/test.png'));
+      expect(file.size, equals(1024));
+    });
+
+    test('DarwinPlatformFile.size is null when not reported', () {
+      final file = DarwinPlatformFile.fromMap({
+        'name': 'test.png',
+        'path': '/tmp/test.png',
+      });
+      expect(file.size, isNull);
     });
 
     test(

--- a/packages/file_picker_darwin/test/file_picker_darwin_test.dart
+++ b/packages/file_picker_darwin/test/file_picker_darwin_test.dart
@@ -23,15 +23,15 @@ void main() {
       });
       expect(file.name, equals('test.png'));
       expect(file.uri.path, equals('/tmp/test.png'));
-      expect(file.size, equals(1024));
+      expect(file.lengthSync(), equals(1024));
     });
 
-    test('DarwinPlatformFile.size is null when not reported', () {
+    test('DarwinPlatformFile.lengthSync() is null when not reported', () {
       final file = DarwinPlatformFile.fromMap({
         'name': 'test.png',
         'path': '/tmp/test.png',
       });
-      expect(file.size, isNull);
+      expect(file.lengthSync(), isNull);
     });
 
     test(

--- a/packages/file_picker_linux/CHANGELOG.md
+++ b/packages/file_picker_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- Implemented `PlatformFile.size`. XDG Desktop Portals only return a file path, not its size, so this returns `null` on Linux, use `length()` to actually read it from disk.
+
 ## 1.0.2
 
 - Fixed `LinuxOptions.lockParentWindow` and `LinuxOptions.acceptLabel` being silently ignored. Passing a plain `LinuxOptions` fell back to a default `FilePickerLinuxOptions`, dropping whatever the caller had set, which is the exact API the deprecation on `FilePicker.pickFiles` points to. [#2183](https://github.com/miguelpruivo/flutter_file_picker/issues/2183)

--- a/packages/file_picker_linux/CHANGELOG.md
+++ b/packages/file_picker_linux/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.1.0
 
-- Implemented `PlatformFile.size`. XDG Desktop Portals only return a file path, not its size, so this returns `null` on Linux, use `length()` to actually read it from disk.
+- Implemented `PlatformFile.lengthSync()`. XDG Desktop Portals only return a file path, not its size, so this returns `null` on Linux, use `length()` to actually read it from disk.
 
 ## 1.0.2
 

--- a/packages/file_picker_linux/lib/src/linux_platform_file.dart
+++ b/packages/file_picker_linux/lib/src/linux_platform_file.dart
@@ -50,6 +50,8 @@ base class LinuxPlatformFile extends PlatformFile {
     return XFile(uri.toString(), name: name);
   }
 
+  /// `null` for a picked file. XDG Desktop Portals only return a file path,
+  /// not its size; use [length] to read it from disk instead.
   @override
   int? get size {
     final len = _bytesLength;

--- a/packages/file_picker_linux/lib/src/linux_platform_file.dart
+++ b/packages/file_picker_linux/lib/src/linux_platform_file.dart
@@ -50,8 +50,10 @@ base class LinuxPlatformFile extends PlatformFile {
     return XFile(uri.toString(), name: name);
   }
 
-  /// `null` for a picked file. XDG Desktop Portals only return a file path,
-  /// not its size; use [length] to read it from disk instead.
+  /// Only known when this file was created with its bytes already in hand.
+  ///
+  /// XDG Desktop Portals return a path and no size, so a picked file reports
+  /// `null` here and [length] has to read the file to answer.
   @override
   int? get size {
     final len = _bytesLength;

--- a/packages/file_picker_linux/lib/src/linux_platform_file.dart
+++ b/packages/file_picker_linux/lib/src/linux_platform_file.dart
@@ -55,7 +55,7 @@ base class LinuxPlatformFile extends PlatformFile {
   /// XDG Desktop Portals return a path and no size, so a picked file reports
   /// `null` here and [length] has to read the file to answer.
   @override
-  int? get size {
+  int? lengthSync() {
     final len = _bytesLength;
     return (len != null && len > 0) ? len : null;
   }

--- a/packages/file_picker_linux/lib/src/linux_platform_file.dart
+++ b/packages/file_picker_linux/lib/src/linux_platform_file.dart
@@ -51,6 +51,12 @@ base class LinuxPlatformFile extends PlatformFile {
   }
 
   @override
+  int? get size {
+    final len = _bytesLength;
+    return (len != null && len > 0) ? len : null;
+  }
+
+  @override
   Future<int> length() async {
     final len = _bytesLength;
     if (len != null && len > 0) return len;

--- a/packages/file_picker_linux/pubspec.yaml
+++ b/packages/file_picker_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_picker_linux
 description: Linux implementation of the file_picker plugin using GTK3 and XDG Desktop Portals for native file and directory picking.
-version: 1.0.2
+version: 1.1.0
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_linux
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_linux
 topics:
@@ -23,7 +23,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  file_picker_platform_interface: ^3.2.0
+  file_picker_platform_interface: ^3.3.0
   cross_file: ^0.3.5+4
   dbus: ^0.7.13
   path: ^1.9.0

--- a/packages/file_picker_linux/test/file_picker_linux_test.dart
+++ b/packages/file_picker_linux/test/file_picker_linux_test.dart
@@ -19,15 +19,15 @@ void main() {
       expect(file.uri.path, equals('/tmp/test.png'));
     });
 
-    test('LinuxPlatformFile.size reflects bytesLength when known', () {
+    test('LinuxPlatformFile.lengthSync() reflects bytesLength when known', () {
       final withoutBytes = LinuxPlatformFile.fromPath('/tmp/test.png');
-      expect(withoutBytes.size, isNull);
+      expect(withoutBytes.lengthSync(), isNull);
 
       final withBytes = LinuxPlatformFile.fromPath(
         '/tmp/test.png',
         bytes: Uint8List.fromList([1, 2, 3]),
       );
-      expect(withBytes.size, equals(3));
+      expect(withBytes.lengthSync(), equals(3));
     });
 
     test('Filter constructs filters correctly', () {

--- a/packages/file_picker_linux/test/file_picker_linux_test.dart
+++ b/packages/file_picker_linux/test/file_picker_linux_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:file_picker_linux/file_picker_linux.dart';
 import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -15,6 +17,17 @@ void main() {
       final file = LinuxPlatformFile.fromPath('/tmp/test.png');
       expect(file.name, equals('test.png'));
       expect(file.uri.path, equals('/tmp/test.png'));
+    });
+
+    test('LinuxPlatformFile.size reflects bytesLength when known', () {
+      final withoutBytes = LinuxPlatformFile.fromPath('/tmp/test.png');
+      expect(withoutBytes.size, isNull);
+
+      final withBytes = LinuxPlatformFile.fromPath(
+        '/tmp/test.png',
+        bytes: Uint8List.fromList([1, 2, 3]),
+      );
+      expect(withBytes.size, equals(3));
     });
 
     test('Filter constructs filters correctly', () {

--- a/packages/file_picker_platform_interface/CHANGELOG.md
+++ b/packages/file_picker_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.0
+
+- Added `PlatformFile.size`, a nullable `int` that returns the file's size in bytes immediately when the native picker already reported it, without doing any I/O. Returns `null` when it isn't known upfront; use `length()` in that case, which falls back to reading the file. Restores a synchronous way to get a file's size, addressing [#2187](https://github.com/miguelpruivo/flutter_file_picker/issues/2187).
+
 ## 3.2.0
 
 - Added `FilePickerPlatform.skipEntitlementsChecks()`, a no-op default hook that platform implementations can override. Lets `file_picker` dispatch through the platform interface instead of importing `file_picker_darwin` directly, which kept the facade package from being wasm compatible.

--- a/packages/file_picker_platform_interface/CHANGELOG.md
+++ b/packages/file_picker_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.3.0
 
-- Added `PlatformFile.size`, a nullable `int` that returns the file's size in bytes, as provided by the underlying file picker result. 
+- Added `PlatformFile.lengthSync()`, a nullable `int` returning the file's length in bytes as provided by the underlying file picker result, or `null` when it did not report one. Named to pair with the existing `length()`, the same way `dart:io`'s `File` does.
 
 ## 3.2.0
 

--- a/packages/file_picker_platform_interface/CHANGELOG.md
+++ b/packages/file_picker_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.3.0
 
-- Added `PlatformFile.size`, a nullable `int` that returns the file's size in bytes immediately when the native picker already reported it, without doing any I/O. Returns `null` when it isn't known upfront; use `length()` in that case, which falls back to reading the file. Restores a synchronous way to get a file's size, addressing [#2187](https://github.com/miguelpruivo/flutter_file_picker/issues/2187).
+- Added `PlatformFile.size`, a nullable `int` that returns the file's size in bytes, as provided by the underlying file picker result. 
 
 ## 3.2.0
 

--- a/packages/file_picker_platform_interface/lib/src/platform_file.dart
+++ b/packages/file_picker_platform_interface/lib/src/platform_file.dart
@@ -34,13 +34,13 @@ abstract base class PlatformFile {
   /// Get this file as an [XFile].
   XFile get xFile;
 
-  /// The size of the file in bytes, if already known without doing I/O, or
+  /// The length of the file in bytes, if already known without doing I/O, or
   /// `null` otherwise.
   ///
   /// Native pickers usually report a file's size as part of the pick result,
   /// in which case this returns it immediately. When they don't, use
   /// [length] instead, which falls back to reading the file to find out.
-  int? get size;
+  int? lengthSync();
 
   /// Get the length of the file in bytes.
   Future<int> length();

--- a/packages/file_picker_platform_interface/lib/src/platform_file.dart
+++ b/packages/file_picker_platform_interface/lib/src/platform_file.dart
@@ -34,6 +34,14 @@ abstract base class PlatformFile {
   /// Get this file as an [XFile].
   XFile get xFile;
 
+  /// The size of the file in bytes, if already known without doing I/O, or
+  /// `null` otherwise.
+  ///
+  /// Native pickers usually report a file's size as part of the pick result,
+  /// in which case this returns it immediately. When they don't, use
+  /// [length] instead, which falls back to reading the file to find out.
+  int? get size;
+
   /// Get the length of the file in bytes.
   Future<int> length();
 

--- a/packages/file_picker_platform_interface/pubspec.yaml
+++ b/packages/file_picker_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_picker_platform_interface
 description: A common platform interface for the file_picker plugin, defining the shared API surface and data contracts across platforms.
-version: 3.2.0
+version: 3.3.0
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_platform_interface
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_platform_interface
 topics:

--- a/packages/file_picker_platform_interface/test/platform_file_test.dart
+++ b/packages/file_picker_platform_interface/test/platform_file_test.dart
@@ -17,7 +17,7 @@ base class _TestPlatformFile extends PlatformFile {
   XFile get xFile => XFile(name);
 
   @override
-  int? get size => null;
+  int? lengthSync() => null;
 
   @override
   Future<int> length() async => 0;

--- a/packages/file_picker_platform_interface/test/platform_file_test.dart
+++ b/packages/file_picker_platform_interface/test/platform_file_test.dart
@@ -17,6 +17,9 @@ base class _TestPlatformFile extends PlatformFile {
   XFile get xFile => XFile(name);
 
   @override
+  int? get size => null;
+
+  @override
   Future<int> length() async => 0;
 
   @override

--- a/packages/file_picker_web/CHANGELOG.md
+++ b/packages/file_picker_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.1.0
 
-- Implemented `PlatformFile.size`, returning the browser's `File.size` (or the loaded bytes' length) synchronously, without doing any I/O.
+- Implemented `PlatformFile.lengthSync()`, returning the browser's `File.size` (or the loaded bytes' length) synchronously, without doing any I/O.
 
 ## 3.0.3
 

--- a/packages/file_picker_web/CHANGELOG.md
+++ b/packages/file_picker_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0
+
+- Implemented `PlatformFile.size`, returning the browser's `File.size` (or the loaded bytes' length) synchronously, without doing any I/O.
+
 ## 3.0.3
 
 - Tightened the `file_picker_platform_interface` lower bound to `^3.2.0`. This package's `pickFile()`/`pickFiles()` signatures reference `DarwinOptions`, added in that version, so resolving against an older one would fail to compile.

--- a/packages/file_picker_web/lib/src/web_platform_file.dart
+++ b/packages/file_picker_web/lib/src/web_platform_file.dart
@@ -58,7 +58,7 @@ base class WebPlatformFile extends PlatformFile {
 
   /// The browser's `File.size`, or the loaded bytes' length.
   @override
-  int? get size {
+  int? lengthSync() {
     final len = _bytesLength;
     if (len != null && len > 0) return len;
     return _bytes?.length;

--- a/packages/file_picker_web/lib/src/web_platform_file.dart
+++ b/packages/file_picker_web/lib/src/web_platform_file.dart
@@ -56,6 +56,13 @@ base class WebPlatformFile extends PlatformFile {
     return XFile(uri.toString(), name: name, bytes: _bytes);
   }
 
+  @override
+  int? get size {
+    final len = _bytesLength;
+    if (len != null && len > 0) return len;
+    return _bytes?.length;
+  }
+
   /// Asynchronously calculates and returns the size of the file in bytes.
   @override
   Future<int> length() async {

--- a/packages/file_picker_web/lib/src/web_platform_file.dart
+++ b/packages/file_picker_web/lib/src/web_platform_file.dart
@@ -56,6 +56,7 @@ base class WebPlatformFile extends PlatformFile {
     return XFile(uri.toString(), name: name, bytes: _bytes);
   }
 
+  /// The browser's `File.size`, or the loaded bytes' length.
   @override
   int? get size {
     final len = _bytesLength;

--- a/packages/file_picker_web/pubspec.yaml
+++ b/packages/file_picker_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_picker_web
 description: Web platform implementation of the file_picker plugin, providing browser file selection, file streaming, and file loading.
-version: 3.0.3
+version: 3.1.0
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_web
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_web
 topics:
@@ -26,7 +26,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  file_picker_platform_interface: ^3.2.0
+  file_picker_platform_interface: ^3.3.0
   cross_file: ^0.3.5+4
   meta: ^1.17.0
   path: ^1.9.1

--- a/packages/file_picker_web/test/file_picker_web_test.dart
+++ b/packages/file_picker_web/test/file_picker_web_test.dart
@@ -13,14 +13,14 @@ void main() {
     );
     expect(file.name, 'test.txt');
     expect(file.uri, Uri.parse('blob:http://localhost/123'));
-    expect(file.size, 4);
+    expect(file.lengthSync(), 4);
   });
 
-  test('WebPlatformFile.size is null when not known', () {
+  test('WebPlatformFile.lengthSync() is null when not known', () {
     final file = WebPlatformFile(
       name: 'test.txt',
       uri: Uri.parse('blob:http://localhost/123'),
     );
-    expect(file.size, isNull);
+    expect(file.lengthSync(), isNull);
   });
 }

--- a/packages/file_picker_web/test/file_picker_web_test.dart
+++ b/packages/file_picker_web/test/file_picker_web_test.dart
@@ -13,5 +13,14 @@ void main() {
     );
     expect(file.name, 'test.txt');
     expect(file.uri, Uri.parse('blob:http://localhost/123'));
+    expect(file.size, 4);
+  });
+
+  test('WebPlatformFile.size is null when not known', () {
+    final file = WebPlatformFile(
+      name: 'test.txt',
+      uri: Uri.parse('blob:http://localhost/123'),
+    );
+    expect(file.size, isNull);
   });
 }

--- a/packages/file_picker_windows/CHANGELOG.md
+++ b/packages/file_picker_windows/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Desktop (Windows)
 
-- Implemented `PlatformFile.size`. The picker only returns a file path, not its size, so this returns `null` on Windows, use `length()` to actually read it from disk.
+- Implemented `PlatformFile.lengthSync()`. The picker only returns a file path, not its size, so this returns `null` on Windows, use `length()` to actually read it from disk.
 
 ## 1.1.0
 

--- a/packages/file_picker_windows/CHANGELOG.md
+++ b/packages/file_picker_windows/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.0
+
+#### Desktop (Windows)
+
+- Implemented `PlatformFile.size`. The picker only returns a file path, not its size, so this returns `null` on Windows, use `length()` to actually read it from disk.
+
 ## 1.1.0
 
 #### Desktop (Windows)

--- a/packages/file_picker_windows/lib/src/windows_platform_file.dart
+++ b/packages/file_picker_windows/lib/src/windows_platform_file.dart
@@ -50,6 +50,8 @@ base class WindowsPlatformFile extends PlatformFile {
     return XFile(uri.toString(), name: name);
   }
 
+  /// `null` for a picked file. The picker only returns a file path, not its
+  /// size; use [length] to read it from disk instead.
   @override
   int? get size {
     final len = _bytesLength;

--- a/packages/file_picker_windows/lib/src/windows_platform_file.dart
+++ b/packages/file_picker_windows/lib/src/windows_platform_file.dart
@@ -55,7 +55,7 @@ base class WindowsPlatformFile extends PlatformFile {
   /// The native dialog returns a path and no size, so a picked file reports
   /// `null` here and [length] has to read the file to answer.
   @override
-  int? get size {
+  int? lengthSync() {
     final len = _bytesLength;
     return (len != null && len > 0) ? len : null;
   }

--- a/packages/file_picker_windows/lib/src/windows_platform_file.dart
+++ b/packages/file_picker_windows/lib/src/windows_platform_file.dart
@@ -50,8 +50,10 @@ base class WindowsPlatformFile extends PlatformFile {
     return XFile(uri.toString(), name: name);
   }
 
-  /// `null` for a picked file. The picker only returns a file path, not its
-  /// size; use [length] to read it from disk instead.
+  /// Only known when this file was created with its bytes already in hand.
+  ///
+  /// The native dialog returns a path and no size, so a picked file reports
+  /// `null` here and [length] has to read the file to answer.
   @override
   int? get size {
     final len = _bytesLength;

--- a/packages/file_picker_windows/lib/src/windows_platform_file.dart
+++ b/packages/file_picker_windows/lib/src/windows_platform_file.dart
@@ -51,6 +51,12 @@ base class WindowsPlatformFile extends PlatformFile {
   }
 
   @override
+  int? get size {
+    final len = _bytesLength;
+    return (len != null && len > 0) ? len : null;
+  }
+
+  @override
   Future<int> length() async {
     final len = _bytesLength;
     if (len != null && len > 0) return len;

--- a/packages/file_picker_windows/pubspec.yaml
+++ b/packages/file_picker_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: windows_file_picker
 description: Windows implementation of the file_picker plugin using Win32 COM APIs for native file and directory picking.
-version: 1.1.0
+version: 1.2.0
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_windows
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_windows
 topics:
@@ -23,7 +23,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  file_picker_platform_interface: ^3.2.0
+  file_picker_platform_interface: ^3.3.0
   cross_file: ^0.3.5+4
   ffi: ^2.2.0
   meta: ^1.17.0

--- a/packages/file_picker_windows/test/file_picker_windows_test.dart
+++ b/packages/file_picker_windows/test/file_picker_windows_test.dart
@@ -21,18 +21,21 @@ void main() {
       expect(file.uri.path, equals('/C:/Users/Test/file.txt'));
     });
 
-    test('WindowsPlatformFile.size reflects bytesLength when known', () {
-      final withoutBytes = WindowsPlatformFile.fromPath(
-        r'C:\Users\Test\file.txt',
-      );
-      expect(withoutBytes.size, isNull);
+    test(
+      'WindowsPlatformFile.lengthSync() reflects bytesLength when known',
+      () {
+        final withoutBytes = WindowsPlatformFile.fromPath(
+          r'C:\Users\Test\file.txt',
+        );
+        expect(withoutBytes.lengthSync(), isNull);
 
-      final withBytes = WindowsPlatformFile.fromPath(
-        r'C:\Users\Test\file.txt',
-        bytes: Uint8List.fromList([1, 2, 3]),
-      );
-      expect(withBytes.size, equals(3));
-    });
+        final withBytes = WindowsPlatformFile.fromPath(
+          r'C:\Users\Test\file.txt',
+          bytes: Uint8List.fromList([1, 2, 3]),
+        );
+        expect(withBytes.lengthSync(), equals(3));
+      },
+    );
 
     test('FilePickerWindowsOptions contains expected properties', () {
       const options = FilePickerWindowsOptions(

--- a/packages/file_picker_windows/test/file_picker_windows_test.dart
+++ b/packages/file_picker_windows/test/file_picker_windows_test.dart
@@ -1,4 +1,5 @@
 import 'dart:isolate';
+import 'dart:typed_data';
 
 import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
 import 'package:windows_file_picker/src/open_save_file_args.dart';
@@ -18,6 +19,19 @@ void main() {
       final file = WindowsPlatformFile.fromPath(r'C:\Users\Test\file.txt');
       expect(file.name, equals('file.txt'));
       expect(file.uri.path, equals('/C:/Users/Test/file.txt'));
+    });
+
+    test('WindowsPlatformFile.size reflects bytesLength when known', () {
+      final withoutBytes = WindowsPlatformFile.fromPath(
+        r'C:\Users\Test\file.txt',
+      );
+      expect(withoutBytes.size, isNull);
+
+      final withBytes = WindowsPlatformFile.fromPath(
+        r'C:\Users\Test\file.txt',
+        bytes: Uint8List.fromList([1, 2, 3]),
+      );
+      expect(withBytes.size, equals(3));
     });
 
     test('FilePickerWindowsOptions contains expected properties', () {

--- a/tool/test/facade_constraints_test.dart
+++ b/tool/test/facade_constraints_test.dart
@@ -1,0 +1,155 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Guards the facade's lower bounds against the packages this repo publishes.
+///
+/// `pub downgrade` in CI resolves every dependency to its lowest allowed
+/// version and builds, which catches a stale bound *once the rest of the set
+/// has moved past it*. It cannot catch a release where the interface bound and
+/// the implementation bounds are stale together: the minimum set is then
+/// internally consistent and compiles, while pub is still free to pair the new
+/// interface with an old implementation in a real app.
+///
+/// That is how both
+/// https://github.com/vicajilau/flutter_file_picker/issues/2186 and the
+/// `PlatformFile.size` release nearly shipped, so this asserts the simpler
+/// property the downgrade build cannot see: the facade must require at least
+/// what this repo is about to publish.
+void main() {
+  test('facade requires at least the versions this repo publishes', () {
+    final root = _repoRoot();
+    final workspace = _workspacePackages(root);
+
+    final facade = workspace['file_picker'];
+    expect(facade, isNotNull, reason: 'file_picker is not in the workspace');
+
+    final dependencies = _dependencies(
+      File('${facade!.dir}/pubspec.yaml').readAsStringSync(),
+    );
+
+    final problems = <String>[];
+    for (final entry in workspace.entries) {
+      final name = entry.key;
+      if (name == 'file_picker') continue;
+
+      final constraint = dependencies[name];
+      if (constraint == null) continue; // not a facade dependency
+
+      final declared = _lowerBound(constraint);
+      if (declared == null) {
+        problems.add('$name: cannot read a lower bound from "$constraint"');
+        continue;
+      }
+      if (_compare(declared, entry.value.version) < 0) {
+        problems.add(
+          '$name: facade allows >=$declared but this repo publishes '
+          '${entry.value.version}',
+        );
+      }
+    }
+
+    expect(
+      problems,
+      isEmpty,
+      reason:
+          'packages/file_picker/pubspec.yaml is behind the workspace:\n'
+          '  ${problems.join('\n  ')}\n'
+          'Raise those bounds. Otherwise pub can pair the new platform '
+          'interface with an implementation released before it.',
+    );
+  });
+}
+
+class _Package {
+  _Package(this.dir, this.version);
+  final String dir;
+  final String version;
+}
+
+Directory _repoRoot() {
+  var dir = Directory.current;
+  while (true) {
+    final pubspec = File('${dir.path}/pubspec.yaml');
+    if (pubspec.existsSync() &&
+        pubspec.readAsStringSync().contains(
+          RegExp(r'^workspace:', multiLine: true),
+        )) {
+      return dir;
+    }
+    final parent = dir.parent;
+    if (parent.path == dir.path) {
+      fail('Could not find the workspace root from ${Directory.current.path}');
+    }
+    dir = parent;
+  }
+}
+
+Map<String, _Package> _workspacePackages(Directory root) {
+  final rootPubspec = File('${root.path}/pubspec.yaml').readAsStringSync();
+  final dirs = RegExp(
+    r'^\s+- (packages/\S+)$',
+    multiLine: true,
+  ).allMatches(rootPubspec).map((m) => '${root.path}/${m.group(1)}');
+
+  final packages = <String, _Package>{};
+  for (final dir in dirs) {
+    final pubspec = File('$dir/pubspec.yaml');
+    if (!pubspec.existsSync()) continue;
+    final text = pubspec.readAsStringSync();
+    final name = RegExp(
+      r'^name:\s*(\S+)',
+      multiLine: true,
+    ).firstMatch(text)?.group(1);
+    final version = RegExp(
+      r'^version:\s*(\S+)',
+      multiLine: true,
+    ).firstMatch(text)?.group(1);
+    if (name != null && version != null) {
+      packages[name] = _Package(dir, version);
+    }
+  }
+  return packages;
+}
+
+Map<String, String> _dependencies(String pubspec) {
+  final result = <String, String>{};
+  var inside = false;
+  for (final line in pubspec.split('\n')) {
+    if (line.startsWith('dependencies:')) {
+      inside = true;
+      continue;
+    }
+    if (inside && line.isNotEmpty && !line.startsWith(' ')) break;
+    if (!inside) continue;
+    final match = RegExp(r'^  ([a-z_0-9]+):\s*(\S.*)$').firstMatch(line);
+    if (match != null) result[match.group(1)!] = match.group(2)!.trim();
+  }
+  return result;
+}
+
+String? _lowerBound(String constraint) {
+  final trimmed = constraint.trim().replaceAll(RegExp('^["\']|["\']\$'), '');
+  return RegExp(r'^\^([0-9]\S*)').firstMatch(trimmed)?.group(1) ??
+      RegExp(r'>=\s*([0-9]\S*)').firstMatch(trimmed)?.group(1) ??
+      RegExp(r'^([0-9]\S*)$').firstMatch(trimmed)?.group(1);
+}
+
+int _compare(String a, String b) {
+  List<int> parts(String v) => v
+      .split('+')
+      .first
+      .split('-')
+      .first
+      .split('.')
+      .map((p) => int.tryParse(p) ?? 0)
+      .toList();
+  final x = parts(a);
+  final y = parts(b);
+  for (var i = 0; i < 3; i++) {
+    final l = i < x.length ? x[i] : 0;
+    final r = i < y.length ? y[i] : 0;
+    if (l != r) return l.compareTo(r);
+  }
+  return 0;
+}

--- a/tool/test/facade_constraints_test.dart
+++ b/tool/test/facade_constraints_test.dart
@@ -1,50 +1,168 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// Guards the facade's lower bounds against the packages this repo publishes.
+/// Guards the facade against allowing a platform implementation that predates
+/// the platform interface it requires.
 ///
-/// `pub downgrade` in CI resolves every dependency to its lowest allowed
-/// version and builds, which catches a stale bound *once the rest of the set
-/// has moved past it*. It cannot catch a release where the interface bound and
-/// the implementation bounds are stale together: the minimum set is then
-/// internally consistent and compiles, while pub is still free to pair the new
-/// interface with an old implementation in a real app.
+/// The `pub downgrade` build in CI resolves everything to its lowest allowed
+/// version, which is internally consistent whenever the interface bound and
+/// the implementation bounds are stale together. It never produces the pairing
+/// that actually breaks, the newest interface next to the oldest allowed
+/// implementation, so it cannot see this on its own. That pairing is what
+/// https://github.com/vicajilau/flutter_file_picker/issues/2186 was.
 ///
-/// That is how both
-/// https://github.com/vicajilau/flutter_file_picker/issues/2186 and the
-/// `PlatformFile.size` release nearly shipped, so this asserts the simpler
-/// property the downgrade build cannot see: the facade must require at least
-/// what this repo is about to publish.
+/// The property checked here is the one that holds regardless of release
+/// order, including the staged flow where the interface is published on its
+/// own before the implementations catch up: for every implementation, the
+/// facade's lower bound must be at least the first published version of that
+/// implementation built against the interface the facade requires.
+const String interfacePackage = 'file_picker_platform_interface';
+
 void main() {
-  test('facade requires at least the versions this repo publishes', () {
+  group('constraint arithmetic', () {
+    test('lowerBound reads the usual constraint shapes', () {
+      expect(lowerBound('^1.0.3'), '1.0.3');
+      expect(lowerBound('>=1.0.3 <2.0.0'), '1.0.3');
+      expect(lowerBound('1.0.3'), '1.0.3');
+      expect(lowerBound('any'), isNull);
+    });
+
+    test('compareVersions orders by major, minor and patch', () {
+      expect(compareVersions('1.1.0', '1.0.9'), greaterThan(0));
+      expect(compareVersions('1.0.2', '1.0.10'), lessThan(0));
+      expect(compareVersions('3.0.3', '3.0.3'), 0);
+      expect(compareVersions('1.0.1+2', '1.0.1'), 0);
+    });
+
+    test('parseDependencies stops at the next top level section', () {
+      const pubspec =
+          '''
+name: file_picker
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+  $interfacePackage: ^3.2.0
+  windows_file_picker: ^1.1.0
+
+dev_dependencies:
+  flutter_lints: ^6.0.0
+''';
+      final deps = parseDependencies(pubspec);
+      expect(deps[interfacePackage], '^3.2.0');
+      expect(deps['windows_file_picker'], '^1.1.0');
+      expect(deps.containsKey('flutter_lints'), isFalse);
+    });
+  });
+
+  group('firstCompatibleVersion', () {
+    // What pub.dev reports for windows_file_picker: every 1.0.x predates the
+    // DarwinOptions parameter, only 1.1.0 was built against the interface that
+    // introduced it.
+    const published = {
+      '1.0.0': '^3.0.0',
+      '1.0.1': '^3.0.0',
+      '1.0.2': '^3.0.0',
+      '1.1.0': '^3.2.0',
+    };
+
+    test('picks the earliest version built against the required interface', () {
+      expect(
+        firstCompatibleVersion(
+          published: published,
+          requiredInterface: '3.2.0',
+        ),
+        '1.1.0',
+      );
+    });
+
+    test('picks the earliest of several compatible versions', () {
+      expect(
+        firstCompatibleVersion(
+          published: {...published, '1.2.0': '^3.2.0'},
+          requiredInterface: '3.2.0',
+        ),
+        '1.1.0',
+      );
+    });
+
+    test('returns null when nothing published is compatible yet', () {
+      expect(
+        firstCompatibleVersion(
+          published: published,
+          requiredInterface: '4.0.0',
+        ),
+        isNull,
+      );
+    });
+
+    test('reproduces issue 2186', () {
+      // The facade asked for the interface at ^3.2.0 while still allowing
+      // windows_file_picker ^1.0.0, and 1.0.0 was built against ^3.0.0.
+      final required = firstCompatibleVersion(
+        published: published,
+        requiredInterface: '3.2.0',
+      );
+      expect(compareVersions('1.0.0', required!), lessThan(0));
+    });
+  });
+
+  test('facade does not allow implementations older than its interface', () async {
     final root = _repoRoot();
-    final workspace = _workspacePackages(root);
+    final facade = File(
+      '${root.path}/packages/file_picker/pubspec.yaml',
+    ).readAsStringSync();
+    final dependencies = parseDependencies(facade);
 
-    final facade = workspace['file_picker'];
-    expect(facade, isNotNull, reason: 'file_picker is not in the workspace');
+    final requiredInterface = lowerBound(dependencies[interfacePackage]!);
+    expect(requiredInterface, isNotNull);
 
-    final dependencies = _dependencies(
-      File('${facade!.dir}/pubspec.yaml').readAsStringSync(),
-    );
+    final Map<String, String> interfaceVersions;
+    try {
+      interfaceVersions = await _publishedInterfaceConstraints(
+        interfacePackage,
+      );
+    } catch (e) {
+      markTestSkipped('pub.dev unreachable: $e');
+      return;
+    }
+
+    // On a branch that bumps the interface, the version the facade now asks for
+    // is not published yet, so there is nothing to compare implementations
+    // against. The staged release flow publishes the interface first, and from
+    // the next release on this check has what it needs.
+    if (!interfaceVersions.containsKey(requiredInterface)) {
+      markTestSkipped(
+        '$interfacePackage $requiredInterface is not published yet, '
+        'so no implementation can have been built against it',
+      );
+      return;
+    }
 
     final problems = <String>[];
-    for (final entry in workspace.entries) {
-      final name = entry.key;
-      if (name == 'file_picker') continue;
-
-      final constraint = dependencies[name];
-      if (constraint == null) continue; // not a facade dependency
-
-      final declared = _lowerBound(constraint);
-      if (declared == null) {
-        problems.add('$name: cannot read a lower bound from "$constraint"');
-        continue;
+    for (final name in _implementationNames(root, dependencies)) {
+      final Map<String, String> published;
+      try {
+        published = await _publishedInterfaceConstraints(name);
+      } catch (e) {
+        markTestSkipped('pub.dev unreachable for $name: $e');
+        return;
       }
-      if (_compare(declared, entry.value.version) < 0) {
+
+      final required = firstCompatibleVersion(
+        published: published,
+        requiredInterface: requiredInterface!,
+      );
+      if (required == null) continue; // not released against it yet
+
+      final declared = lowerBound(dependencies[name]!);
+      if (declared == null || compareVersions(declared, required) < 0) {
         problems.add(
-          '$name: facade allows >=$declared but this repo publishes '
-          '${entry.value.version}',
+          '$name: facade allows >=$declared, but the first version built '
+          'against $interfacePackage >=$requiredInterface is $required',
         );
       }
     }
@@ -53,18 +171,77 @@ void main() {
       problems,
       isEmpty,
       reason:
-          'packages/file_picker/pubspec.yaml is behind the workspace:\n'
-          '  ${problems.join('\n  ')}\n'
-          'Raise those bounds. Otherwise pub can pair the new platform '
-          'interface with an implementation released before it.',
+          'packages/file_picker/pubspec.yaml allows implementations that '
+          'predate the interface it requires:\n  ${problems.join('\n  ')}\n'
+          'Raise those bounds, otherwise pub can resolve a combination that '
+          'satisfies every constraint and does not compile.',
     );
   });
 }
 
-class _Package {
-  _Package(this.dir, this.version);
-  final String dir;
-  final String version;
+/// Reads the `name: constraint` pairs from a pubspec's `dependencies` block.
+Map<String, String> parseDependencies(String pubspec) {
+  final result = <String, String>{};
+  var inside = false;
+  for (final line in const LineSplitter().convert(pubspec)) {
+    if (line.startsWith('dependencies:')) {
+      inside = true;
+      continue;
+    }
+    if (inside && line.isNotEmpty && !line.startsWith(' ')) break;
+    if (!inside) continue;
+    final match = RegExp(r'^  ([a-z_0-9]+):\s*(\S.*)$').firstMatch(line);
+    if (match != null) result[match.group(1)!] = match.group(2)!.trim();
+  }
+  return result;
+}
+
+/// Extracts the lower bound of a pub version constraint.
+String? lowerBound(String constraint) {
+  final trimmed = constraint.trim().replaceAll(RegExp('^["\']|["\']\$'), '');
+  return RegExp(r'^\^([0-9]\S*)').firstMatch(trimmed)?.group(1) ??
+      RegExp(r'>=\s*([0-9]\S*)').firstMatch(trimmed)?.group(1) ??
+      RegExp(r'^([0-9]\S*)$').firstMatch(trimmed)?.group(1);
+}
+
+/// Compares two versions, ignoring build metadata and pre-release suffixes.
+int compareVersions(String a, String b) {
+  List<int> parts(String v) => v
+      .split('+')
+      .first
+      .split('-')
+      .first
+      .split('.')
+      .map((p) => int.tryParse(p) ?? 0)
+      .toList();
+  final x = parts(a);
+  final y = parts(b);
+  for (var i = 0; i < 3; i++) {
+    final l = i < x.length ? x[i] : 0;
+    final r = i < y.length ? y[i] : 0;
+    if (l != r) return l.compareTo(r);
+  }
+  return 0;
+}
+
+/// The earliest published version whose interface constraint is at least
+/// [requiredInterface]. [published] maps a version to the constraint it
+/// declares on the platform interface.
+String? firstCompatibleVersion({
+  required Map<String, String> published,
+  required String requiredInterface,
+}) {
+  final compatible =
+      published.entries
+          .where((e) {
+            final bound = lowerBound(e.value);
+            return bound != null &&
+                compareVersions(bound, requiredInterface) >= 0;
+          })
+          .map((e) => e.key)
+          .toList()
+        ..sort(compareVersions);
+  return compatible.isEmpty ? null : compatible.first;
 }
 
 Directory _repoRoot() {
@@ -85,71 +262,57 @@ Directory _repoRoot() {
   }
 }
 
-Map<String, _Package> _workspacePackages(Directory root) {
+/// Facade dependencies that are implementations maintained in this repository.
+///
+/// Derived from the workspace list rather than hardcoded, so a new platform
+/// package is covered as soon as the facade depends on it.
+List<String> _implementationNames(Directory root, Map<String, String> deps) {
   final rootPubspec = File('${root.path}/pubspec.yaml').readAsStringSync();
-  final dirs = RegExp(
+  final names = <String>[];
+  for (final match in RegExp(
     r'^\s+- (packages/\S+)$',
     multiLine: true,
-  ).allMatches(rootPubspec).map((m) => '${root.path}/${m.group(1)}');
-
-  final packages = <String, _Package>{};
-  for (final dir in dirs) {
-    final pubspec = File('$dir/pubspec.yaml');
+  ).allMatches(rootPubspec)) {
+    final pubspec = File('${root.path}/${match.group(1)}/pubspec.yaml');
     if (!pubspec.existsSync()) continue;
-    final text = pubspec.readAsStringSync();
     final name = RegExp(
       r'^name:\s*(\S+)',
       multiLine: true,
-    ).firstMatch(text)?.group(1);
-    final version = RegExp(
-      r'^version:\s*(\S+)',
-      multiLine: true,
-    ).firstMatch(text)?.group(1);
-    if (name != null && version != null) {
-      packages[name] = _Package(dir, version);
+    ).firstMatch(pubspec.readAsStringSync())?.group(1);
+    if (name == null || name == interfacePackage) continue;
+    if (deps.containsKey(name)) names.add(name);
+  }
+  return names;
+}
+
+/// Maps every published version of [package] to the platform interface
+/// constraint it declares.
+Future<Map<String, String>> _publishedInterfaceConstraints(
+  String package,
+) async {
+  final client = HttpClient()..connectionTimeout = const Duration(seconds: 15);
+  try {
+    final response = await (await client.getUrl(
+      Uri.parse('https://pub.dev/api/packages/$package'),
+    )).close();
+    if (response.statusCode != 200) {
+      throw HttpException('pub.dev returned ${response.statusCode}');
     }
-  }
-  return packages;
-}
+    final body = await response
+        .transform(utf8.decoder)
+        .join()
+        .timeout(const Duration(seconds: 30));
+    final json = jsonDecode(body) as Map<String, Object?>;
 
-Map<String, String> _dependencies(String pubspec) {
-  final result = <String, String>{};
-  var inside = false;
-  for (final line in pubspec.split('\n')) {
-    if (line.startsWith('dependencies:')) {
-      inside = true;
-      continue;
+    final result = <String, String>{};
+    for (final entry in json['versions'] as List) {
+      final version = (entry as Map)['version'] as String;
+      final deps = ((entry['pubspec'] as Map)['dependencies'] as Map?) ?? {};
+      final constraint = deps[interfacePackage];
+      result[version] = constraint is String ? constraint : '';
     }
-    if (inside && line.isNotEmpty && !line.startsWith(' ')) break;
-    if (!inside) continue;
-    final match = RegExp(r'^  ([a-z_0-9]+):\s*(\S.*)$').firstMatch(line);
-    if (match != null) result[match.group(1)!] = match.group(2)!.trim();
+    return result;
+  } finally {
+    client.close();
   }
-  return result;
-}
-
-String? _lowerBound(String constraint) {
-  final trimmed = constraint.trim().replaceAll(RegExp('^["\']|["\']\$'), '');
-  return RegExp(r'^\^([0-9]\S*)').firstMatch(trimmed)?.group(1) ??
-      RegExp(r'>=\s*([0-9]\S*)').firstMatch(trimmed)?.group(1) ??
-      RegExp(r'^([0-9]\S*)$').firstMatch(trimmed)?.group(1);
-}
-
-int _compare(String a, String b) {
-  List<int> parts(String v) => v
-      .split('+')
-      .first
-      .split('-')
-      .first
-      .split('.')
-      .map((p) => int.tryParse(p) ?? 0)
-      .toList();
-  final x = parts(a);
-  final y = parts(b);
-  for (var i = 0; i < 3; i++) {
-    final l = i < x.length ? x[i] : 0;
-    final r = i < y.length ? y[i] : 0;
-    if (l != r) return l.compareTo(r);
-  }
-  return 0;
 }


### PR DESCRIPTION
Fixes #2187.

## The request

`PlatformFile.size` was removed in the v12 federated rewrite without a synchronous replacement, only `Future<int> length()` remains. That forces an `await` for a value most callers already have on hand.

## The fix

Every platform's `PlatformFile` already carries the size the native picker reports, stored in a private `_bytesLength` field. `length()` already returns it immediately when it's known and only falls back to actually reading the file (`xFile.length()`) when it isn't, so the async signature exists for that fallback path, not because getting the size is inherently async.

Added `int? get size` to `PlatformFile`, returning that already known value synchronously, `null` when it isn't known. Matches the shape `extension` and `path` already use on this class.

Per platform, what `size` actually returns:

| Platform | Source | Known upfront? |
| --- | --- | --- |
| Android | native pick result (`FileInfo.size`) | Yes |
| iOS / macOS | native pick result | Yes |
| Web | browser `File.size`, or loaded bytes | Yes |
| Windows | picker only returns a path | No, `null` |
| Linux | XDG portal only returns a path | No, `null` |

Windows and Linux callers fall back to `await length()`, which still works exactly as before.

## What changed

- `file_picker_platform_interface` 3.2.0 → 3.3.0: added the abstract member.
- `file_picker_darwin`, `android_file_picker`, `file_picker_web` bumped (minor): implemented `size` backed by data they already have.
- `file_picker_linux`, `windows_file_picker` bumped (minor): implemented `size`, returns `null` since neither picker reports it.
- Each implementation's `file_picker_platform_interface` lower bound raised to `^3.3.0`, the version that introduces the abstract member they now implement. Learned this the hard way with #2186, an implementation built against an older interface won't have this override and will fail to compile if pub resolves it alongside a newer interface.
- `file_picker` (the facade) is untouched, `PlatformFile` is used through the platform interface as-is, no facade code references `size` directly.

## Test plan

- [x] `flutter analyze` clean across the whole workspace
- [x] `dart format --output=none --set-exit-if-changed` clean
- [x] `flutter test` across the whole workspace, 57 tests pass, including new coverage for `size` on every platform (`web`'s is `@TestOn('browser')` like the rest of that file, doesn't run under the default `flutter test`)