### PR TITLE
fix(android): restore the buildscript classpath as a temporary AGP 9 newDsl workaround

### DIFF
--- a/packages/file_picker_android/CHANGELOG.md
+++ b/packages/file_picker_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+- Restored the module local `buildscript` classpath (AGP 8.5.2, Kotlin Gradle Plugin 1.8.22) that #2154 removed. It fixed `Unresolved reference compileSdk/namespace/minSdk` on some project configurations using AGP 9 with `android.newDsl=false`, reported in [#2170](https://github.com/miguelpruivo/flutter_file_picker/issues/2170). We could not reproduce the failure ourselves, on CI or on a real Windows machine matching every reported detail, but the removal is the only change between the last known-good version and the first broken one, and restoring it is a low risk, effectively a revert.
+
 ## 1.0.3
 
 - Tightened the `file_picker_platform_interface` lower bound to `^3.2.0`. This package's `pickFile()`/`pickFiles()` signatures reference `DarwinOptions`, added in that version, so resolving against an older one would fail to compile.

--- a/packages/file_picker_android/CHANGELOG.md
+++ b/packages/file_picker_android/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.0.4
 
-- Restored the module local `buildscript` classpath (AGP 8.5.2, Kotlin Gradle Plugin 1.8.22) that #2154 removed. It fixed `Unresolved reference compileSdk/namespace/minSdk` on some project configurations using AGP 9 with `android.newDsl=false`, reported in [#2170](https://github.com/miguelpruivo/flutter_file_picker/issues/2170). We could not reproduce the failure ourselves, on CI or on a real Windows machine matching every reported detail, but the removal is the only change between the last known-good version and the first broken one, and restoring it is a low risk, effectively a revert.
+- Restored the module local `buildscript` classpath (AGP 8.5.2, Kotlin Gradle Plugin 1.8.22) that #2154 removed. It fixed `Unresolved reference compileSdk/namespace/minSdk` on project configurations using AGP 9 with `android.newDsl=false` and custom root level Gradle configuration, reported and confirmed fixed against a real affected project in [#2170](https://github.com/miguelpruivo/flutter_file_picker/issues/2170).
+
+  This is a temporary workaround, not a permanent fix. Pinning an older AGP via a module's own `buildscript` classpath while the consuming app applies a newer one through the `plugins` block is generally discouraged, and #2154 removed it for exactly that reason. Restoring it papers over a gap in Flutter's own AGP 9 `newDsl` migration, which is still in progress ([flutter/flutter#180137](https://github.com/flutter/flutter/issues/180137)): the interim compatibility shim that lets `android.newDsl=false` projects use AGP 9 does not appear to reliably reach plugin modules that don't declare their own classpath, at least for some custom root level Gradle setups. Remove this block again once that migration lands upstream and `android.newDsl=false` is no longer needed.
 
 ## 1.0.3
 

--- a/packages/file_picker_android/android/build.gradle.kts
+++ b/packages/file_picker_android/android/build.gradle.kts
@@ -6,6 +6,15 @@ import org.gradle.kotlin.dsl.withGroovyBuilder
 group = "com.mr.flutter.plugin.filepicker"
 version = "1.0-SNAPSHOT"
 
+// Temporary workaround, not a permanent fix. Pinning an older AGP here while
+// the consuming app applies a newer one through the `plugins` block is
+// generally discouraged, this module didn't declare it until it broke
+// `android.newDsl=false` projects with custom root level Gradle
+// configuration (#2170). Flutter's own AGP 9 `newDsl` migration is still in
+// progress (https://github.com/flutter/flutter/issues/180137); its interim
+// compatibility shim doesn't appear to reliably reach plugin modules that
+// don't declare their own classpath. Remove this block again once that
+// migration lands upstream and `android.newDsl=false` is no longer needed.
 buildscript {
     repositories {
         google()

--- a/packages/file_picker_android/android/build.gradle.kts
+++ b/packages/file_picker_android/android/build.gradle.kts
@@ -6,6 +6,18 @@ import org.gradle.kotlin.dsl.withGroovyBuilder
 group = "com.mr.flutter.plugin.filepicker"
 version = "1.0-SNAPSHOT"
 
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.5.2")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22")
+    }
+}
+
 rootProject.allprojects {
     repositories {
         google()

--- a/packages/file_picker_android/pubspec.yaml
+++ b/packages/file_picker_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: android_file_picker
 description: Android implementation of the file_picker plugin, supporting file picking, saving, and Storage Access Framework (SAF) URI grants.
-version: 1.0.3
+version: 1.0.4
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_android
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_android
 topics:


### PR DESCRIPTION
Fixes #2170.

## The bug

`packages/file_picker_android/android/build.gradle.kts` fails with `Unresolved reference compileSdk/namespace/minSdk` (and similar) on projects using AGP 9 with `android.newDsl=false` and custom root level Gradle configuration. Reported in #2170, confirmed against a real affected project (Windows, AGP 9.3.0, custom root Gradle config, Huawei AG Connect integration) after applying this exact fix, see the comment on the issue.

We could not reproduce the failure ourselves, neither on CI nor on a real Windows machine matching every reported variable we knew about. The module local `buildscript` classpath removed in #2154 is the only change between the last known-good version and the first broken one, and the reporter's own testing confirms restoring it resolves the failure in their project.

## The fix, and why it's a workaround, not a permanent one

This PR reverts #2154: restores the `buildscript` classpath (AGP 8.5.2, Kotlin Gradle Plugin 1.8.22).

Worth being explicit about what this is and isn't. General Gradle/AGP guidance discourages exactly this pattern, pinning an older AGP via a module's own `buildscript` classpath while the consuming app applies a newer one through the `plugins` block, and that's precisely why #2154 removed it in the first place, not a mistake on its part.

What changed the picture: Flutter's own migration to the new AGP 9 DSL is still in progress upstream ([flutter/flutter#180137](https://github.com/flutter/flutter/issues/180137)). In the meantime, Flutter's docs describe an interim compatibility shim that lets `android.newDsl=false` projects use AGP 9, but that shim does not appear to reliably reach plugin modules that don't declare their own classpath, at least for some custom root level Gradle configurations, which is what the reporter's project has. Restoring the classpath here works around that gap.

Both the changelog and a code comment on the block itself say this explicitly, including a note to remove it again once #180137 lands upstream and `android.newDsl=false` stops being necessary.

## Verification

- Confirmed by the reporter against their real project: the exact reported errors are gone and the build succeeds. Full report on #2170.
- Bumped `android_file_picker` to 1.0.4 with a changelog entry.

## Test plan

- [x] `dart format`, `flutter analyze` clean (this PR doesn't touch Dart code, verified nothing else regressed)
- [x] Confirmed fixed against the actual failing project (see #2170)