### PR TITLE
docs(windows): drop the redundant platform heading from the changelog

### DIFF
--- a/packages/file_picker_windows/CHANGELOG.md
+++ b/packages/file_picker_windows/CHANGELOG.md
@@ -1,14 +1,10 @@
 ## 1.1.0
 
-#### Desktop (Windows)
-
 - Migrated `pickFile()`, `pickFiles()`, and `saveFile()` from the legacy `GetOpenFileNameW`/`GetSaveFileNameW` common dialogs to the modern `IFileOpenDialog`/`IFileSaveDialog` COM APIs, the same pattern `getDirectoryPath()` already used. This is a prerequisite for supporting custom dialog button text and other Common Item Dialog features on those entry points. Fixes [#2173](https://github.com/miguelpruivo/flutter_file_picker/issues/2173).
 - Removed the internal Win32 helpers tied to the legacy dialogs (`fileTypeToFileFilter`, `extractSelectedFilesFromOpenFileNameW`, `OPENFILENAMEW`, `GetOpenFileNameW`, `GetSaveFileNameW`, and the `ofn*` constants). These were implementation details of the removed dialog code, not part of the supported plugin API.
 - Tightened the `file_picker_platform_interface` lower bound to `^3.2.0`. This package's `pickFile()`/`pickFiles()` signatures reference `DarwinOptions`, added in that version, so resolving against an older one would fail to compile.
 
 ## 1.0.2
-
-#### Desktop (Windows)
 
 - Fix saved files missing their extension when the user types a file name without one: set `lpstrDefExt` on `OPENFILENAMEW` so Windows appends the default extension (derived from the allowed extensions or the suggested file name). Fixes [#2139](https://github.com/miguelpruivo/flutter_file_picker/issues/2139).
 


### PR DESCRIPTION
Split out of #2191, where @navaronbracke suggested it and we agreed to do it separately.

`file_picker_windows` **is** the Windows implementation, so a `#### Desktop (Windows)` heading above every entry adds nothing. It was carrying two of them.

The remark was "probably the same thing for the other implementations", so I checked, and Windows was the only one left. Android, Darwin, Linux, Web and the platform interface have no platform headings and no platform prefixes on their bullets either.

The facade keeps its own headings (`### Android`, `### General`, `### iOS`, ...). There they earn their place, since one release covers several platforms at once.

Text only, on versions that are already published, so no version bump. It reaches pub.dev with the next release of the package.
